### PR TITLE
multi snapshot retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import { Events } from './app.providers.ts';
       eventStore: {
         client: 'mongodb',
         options: { 
-          url: 'mongodb://localhost:27017' 
+          url: 'mongodb://127.0.0.1:27017' 
         },
       },
       snapshotStore: {

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ export class UserEventListener implements IEventListener {
 ```
 
 ## Snapshots
-Snapshots are an optimization that is completely optional. They come in handy when event-streams become large and reading them out becomes slow.
+Snapshots are an optimization that is completely optional. However, they come in handy when event-streams become large and reading them out becomes slow.
 &nbsp;
 
 ### Snapshot streams
@@ -278,6 +278,7 @@ stream.streamId // account-af9a0775-b868-4063-89d8-ccc81bce3c3d
 
 ### Snapshot store
  The SnapshotStore saves the state of an aggregate at a certain interval and only fetch the events from that version on. Just as the EventStore it needs to be setup, optionally with a tenant pool.
+ Another advantage of using the snapshot handler is that it also creates a snapshot at version 1 of your aggregate, which makes it easier to get a complete set of aggregates of a certain type in your application.
 
 ```typescript
 import { SnapshotStore } from '@ocoda/event-sourcing';

--- a/example/src/application/account.controller.ts
+++ b/example/src/application/account.controller.ts
@@ -82,7 +82,6 @@ export class AccountController {
 
 			await this.commandBus.execute(command);
 		} catch (error) {
-			console.error(error);
 			switch (error.constructor) {
 				case AccountNotFoundException:
 					throw new HttpException(`${error.message} not found`, HttpStatus.NOT_FOUND);

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+	const app = await NestFactory.create(AppModule);
+	await app.listen(3000);
 }
 bootstrap();

--- a/lib/exceptions/application/index.ts
+++ b/lib/exceptions/application/index.ts
@@ -7,6 +7,7 @@ export * from './missing-event-metadata.exception';
 export * from './missing-event-serializer-metadata.exception';
 export * from './missing-query-handler-metadata.exception';
 export * from './missing-query-metadata.exception';
+export * from './missing-snapshot-metadata.exception';
 export * from './missing-store-connection-options.exception';
 export * from './query-handler-not-found.exception';
 export * from './snapshot-not-found.exception';

--- a/lib/exceptions/application/missing-snapshot-metadata.exception.ts
+++ b/lib/exceptions/application/missing-snapshot-metadata.exception.ts
@@ -1,0 +1,5 @@
+export class MissingSnapshotMetadataException extends Error {
+	constructor(handler: Function) {
+		super(`Missing snapshot metadata exception for ${handler.name}. (missing @Snapshot() decorator?)`);
+	}
+}

--- a/lib/exceptions/application/query-handler-not-found.exception.ts
+++ b/lib/exceptions/application/query-handler-not-found.exception.ts
@@ -1,5 +1,5 @@
 export class QueryHandlerNotFoundException extends Error {
-	constructor(queryName: string) {
-		super(`The query handler for the "${queryName}" query was not found`);
+	constructor(query: Function) {
+		super(`The query handler for the "${query.name}" query was not found`);
 	}
 }

--- a/lib/helpers/get-snapshot-metadata.ts
+++ b/lib/helpers/get-snapshot-metadata.ts
@@ -1,0 +1,7 @@
+import { SNAPSHOT_METADATA } from '../decorators';
+import { SnapshotMetadata } from '../interfaces';
+import { AggregateRoot } from '../models';
+
+export const getSnapshotMetadata = <A extends AggregateRoot>(snapshotHandler: Function): SnapshotMetadata<A> => {
+	return Reflect.getMetadata(SNAPSHOT_METADATA, snapshotHandler) ?? {};
+};

--- a/lib/helpers/index.ts
+++ b/lib/helpers/index.ts
@@ -9,4 +9,5 @@ export * from './get-event-metadata';
 export * from './get-event-serializer-metadata';
 export * from './get-query-handler-metadata';
 export * from './get-query-metadata';
+export * from './get-snapshot-metadata';
 export * from './observable-bus';

--- a/lib/integration/snapshot-store/dynamodb.snapshot-store.ts
+++ b/lib/integration/snapshot-store/dynamodb.snapshot-store.ts
@@ -3,16 +3,15 @@ import {
 	CreateTableCommand,
 	DynamoDBClient,
 	GetItemCommand,
-	PutItemCommand,
-	PutItemInput,
 	QueryCommand,
+	TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import { DEFAULT_BATCH_SIZE, StreamReadingDirection } from '../../constants';
 import { SnapshotNotFoundException } from '../../exceptions';
 import { ISnapshot, ISnapshotPool } from '../../interfaces';
 import { AggregateRoot, SnapshotCollection, SnapshotEnvelope, SnapshotStream } from '../../models';
-import { SnapshotFilter, SnapshotStore } from '../../snapshot-store';
+import { LatestSnapshotFilter, SnapshotFilter, SnapshotStore } from '../../snapshot-store';
 
 export interface DynamoSnapshotEntity<A extends AggregateRoot> {
 	streamId: string;
@@ -40,6 +39,20 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 				AttributeDefinitions: [
 					{ AttributeName: 'streamId', AttributeType: 'S' },
 					{ AttributeName: 'version', AttributeType: 'N' },
+					{ AttributeName: 'aggregateName', AttributeType: 'S' },
+					{ AttributeName: 'latest', AttributeType: 'N' },
+				],
+				GlobalSecondaryIndexes: [
+					{
+						IndexName: 'aggregate_index',
+						KeySchema: [
+							{ AttributeName: 'aggregateName', KeyType: 'HASH' },
+							{ AttributeName: 'latest', KeyType: 'RANGE' },
+						],
+						Projection: {
+							ProjectionType: 'ALL',
+						},
+					},
 				],
 				ProvisionedThroughput: {
 					ReadCapacityUnits: 1,
@@ -64,16 +77,14 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 		let batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
 		const KeyConditionExpression = ['streamId = :streamId'];
-		const ExpressionAttributeValues = {
-			':streamId': { S: streamId },
-		};
+		const ExpressionAttributeValues = { ':streamId': { S: streamId } };
 
 		if (fromVersion) {
 			KeyConditionExpression.push('version >= :fromVersion');
 			ExpressionAttributeValues[':fromVersion'] = { N: fromVersion.toString() };
 		}
 
-		const entities = [];
+		const entities: ISnapshot<A>[] = [];
 		let leftToFetch = limit;
 		let ExclusiveStartKey: Record<string, AttributeValue>;
 		do {
@@ -83,18 +94,15 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 					KeyConditionExpression: KeyConditionExpression.join(' AND '),
 					ExclusiveStartKey,
 					ExpressionAttributeValues,
-					...(direction === StreamReadingDirection.BACKWARD && { ScanIndexForward: false }),
+					...(direction === StreamReadingDirection.BACKWARD && {
+						ScanIndexForward: false,
+					}),
 					...(limit && { Limit: Math.min(batch, leftToFetch) }),
 				}),
 			);
 
 			ExclusiveStartKey = LastEvaluatedKey;
-			entities.push(
-				...Items.map((item) => {
-					const { payload } = unmarshall(item);
-					return payload;
-				}),
-			);
+			Items.forEach((item) => entities.push(this.hydrate<A>(item).payload));
 			leftToFetch -= Items.length;
 
 			if (entities.length > 0 && (entities.length === batch || !ExclusiveStartKey || leftToFetch <= 0)) {
@@ -111,20 +119,23 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 	): Promise<ISnapshot<A>> {
 		const collection = SnapshotCollection.get(pool);
 		const { Item } = await this.client.send(
-			new GetItemCommand({ TableName: collection, Key: marshall({ streamId, version }) }),
+			new GetItemCommand({
+				TableName: collection,
+				Key: marshall({ streamId, version }),
+			}),
 		);
 
 		if (!Item) {
 			throw new SnapshotNotFoundException(streamId, version);
 		}
 
-		const { payload } = unmarshall(Item);
+		const { payload } = this.hydrate<A>(Item);
 
 		return payload;
 	}
 
 	async appendSnapshot<A extends AggregateRoot>(
-		{ streamId, aggregateId }: SnapshotStream,
+		{ streamId, aggregateId, aggregate }: SnapshotStream,
 		aggregateVersion: number,
 		snapshot: ISnapshot<A>,
 		pool?: ISnapshotPool,
@@ -136,19 +147,43 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 			version: aggregateVersion,
 		});
 
-		const params: PutItemInput = {
-			TableName: collection,
-			Item: marshall({
-				streamId,
-				payload,
-				version: metadata.version,
-				snapshotId: metadata.snapshotId,
-				aggregateId: metadata.aggregateId,
-				registeredOn: metadata.registeredOn.getTime(),
-			}),
-		};
+		const updateLastItem = [];
+		const lastStreamEntity = await this.getLastStreamEntity(collection, streamId);
 
-		await this.client.send(new PutItemCommand(params));
+		if (lastStreamEntity) {
+			const snapshot = this.hydrate<A>(lastStreamEntity);
+			updateLastItem.push({
+				Update: {
+					TableName: collection,
+					Key: marshall({ streamId, version: snapshot.version }),
+					UpdateExpression: 'SET latest = :latest',
+					ExpressionAttributeValues: { ':latest': { N: 0 } },
+				},
+			});
+		}
+
+		await this.client.send(
+			new TransactWriteItemsCommand({
+				TransactItems: [
+					...updateLastItem,
+					{
+						Put: {
+							TableName: collection,
+							Item: marshall({
+								streamId,
+								payload,
+								version: metadata.version,
+								aggregateName: aggregate,
+								snapshotId: metadata.snapshotId,
+								aggregateId: metadata.aggregateId,
+								registeredOn: metadata.registeredOn.getTime(),
+								latest: 1,
+							}),
+						},
+					},
+				],
+			}),
+		);
 	}
 
 	async getLastSnapshot<A extends AggregateRoot>(
@@ -164,6 +199,7 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 					':streamId': { S: streamId },
 				},
 				ScanIndexForward: false,
+				Limit: 1,
 			}),
 		);
 
@@ -179,28 +215,10 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 		pool?: ISnapshotPool,
 	): Promise<SnapshotEnvelope<A>> {
 		const collection = SnapshotCollection.get(pool);
-		const { Items } = await this.client.send(
-			new QueryCommand({
-				TableName: collection,
-				KeyConditionExpression: 'streamId = :streamId',
-				ExpressionAttributeValues: {
-					':streamId': { S: streamId },
-				},
-				ScanIndexForward: false,
-			}),
-		);
+		const lastSnapshotEntity = await this.getLastStreamEntity<A>(collection, streamId);
 
-		if (Items[0]) {
-			const { payload, snapshotId, aggregateId, version, registeredOn } = unmarshall(
-				Items[0],
-			) as DynamoSnapshotEntity<A>;
-
-			return SnapshotEnvelope.from<A>(payload, {
-				snapshotId,
-				aggregateId,
-				registeredOn: new Date(registeredOn),
-				version,
-			});
+		if (lastSnapshotEntity) {
+			return this.hydrateEnvelope(lastSnapshotEntity);
 		}
 	}
 
@@ -225,7 +243,7 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 			ExpressionAttributeValues[':fromVersion'] = { N: fromVersion.toString() };
 		}
 
-		const entities = [];
+		const entities: SnapshotEnvelope<A>[] = [];
 		let leftToFetch = limit;
 		let ExclusiveStartKey: Record<string, AttributeValue>;
 		do {
@@ -235,25 +253,15 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 					KeyConditionExpression: KeyConditionExpression.join(' AND '),
 					ExclusiveStartKey,
 					ExpressionAttributeValues,
-					...(direction === StreamReadingDirection.BACKWARD && { ScanIndexForward: false }),
+					...(direction === StreamReadingDirection.BACKWARD && {
+						ScanIndexForward: false,
+					}),
 					...(limit && { Limit: Math.min(batch, leftToFetch) }),
 				}),
 			);
 
 			ExclusiveStartKey = LastEvaluatedKey;
-			entities.push(
-				...Items.map((item) => {
-					const { payload, snapshotId, aggregateId, version, registeredOn } = unmarshall(
-						item,
-					) as DynamoSnapshotEntity<A>;
-					return SnapshotEnvelope.from<A>(payload, {
-						snapshotId,
-						aggregateId,
-						registeredOn: new Date(registeredOn),
-						version,
-					});
-				}),
-			);
+			Items.forEach((item) => entities.push(this.hydrateEnvelope(item)));
 			leftToFetch -= Items.length;
 
 			if (entities.length > 0 && (entities.length === batch || !ExclusiveStartKey || leftToFetch <= 0)) {
@@ -270,19 +278,92 @@ export class DynamoDBSnapshotStore extends SnapshotStore {
 	): Promise<SnapshotEnvelope<A>> {
 		const collection = SnapshotCollection.get(pool);
 		const { Item } = await this.client.send(
-			new GetItemCommand({ TableName: collection, Key: marshall({ streamId, version }) }),
+			new GetItemCommand({
+				TableName: collection,
+				Key: marshall({ streamId, version }),
+			}),
 		);
 
 		if (!Item) {
 			throw new SnapshotNotFoundException(streamId, version);
 		}
 
-		const { payload, snapshotId, aggregateId, registeredOn } = unmarshall(Item) as DynamoSnapshotEntity<A>;
-		return SnapshotEnvelope.from<A>(payload, {
-			snapshotId,
-			aggregateId,
-			registeredOn: new Date(registeredOn),
-			version,
+		return this.hydrateEnvelope(Item);
+	}
+
+	async *getLastEnvelopes<A extends AggregateRoot>(
+		aggregateName: string,
+		filter?: LatestSnapshotFilter,
+		pool?: ISnapshotPool,
+	): AsyncGenerator<SnapshotEnvelope<A>[]> {
+		const collection = SnapshotCollection.get(pool);
+
+		let limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		let batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const KeyConditionExpression = ['aggregateName = :aggregateName', ' latest = :latest'];
+		const ExpressionAttributeValues = {
+			':aggregateName': { S: aggregateName },
+			':latest': { N: '1' },
+		};
+
+		const entities: SnapshotEnvelope<A>[] = [];
+		let leftToFetch = limit;
+		let ExclusiveStartKey: Record<string, AttributeValue>;
+		do {
+			const { Items, LastEvaluatedKey } = await this.client.send(
+				new QueryCommand({
+					TableName: collection,
+					IndexName: 'aggregate_index',
+					KeyConditionExpression: KeyConditionExpression.join(' AND '),
+					ExclusiveStartKey,
+					ExpressionAttributeValues,
+					ScanIndexForward: false,
+					...(limit && { Limit: Math.min(batch, leftToFetch) }),
+				}),
+			);
+
+			ExclusiveStartKey = LastEvaluatedKey;
+			Items.forEach((item) => entities.push(this.hydrateEnvelope(item)));
+			leftToFetch -= Items.length;
+
+			if (entities.length > 0 && (entities.length === batch || !ExclusiveStartKey || leftToFetch <= 0)) {
+				yield entities;
+				entities.length = 0;
+			}
+		} while (ExclusiveStartKey && leftToFetch > 0);
+	}
+
+	hydrate<A extends AggregateRoot>(entity: Record<string, AttributeValue>): DynamoSnapshotEntity<A> {
+		return unmarshall(entity) as DynamoSnapshotEntity<A>;
+	}
+
+	hydrateEnvelope<A extends AggregateRoot>(entity: Record<string, AttributeValue>): SnapshotEnvelope<A> {
+		const parsed = this.hydrate<A>(entity);
+		return SnapshotEnvelope.from<A>(parsed.payload, {
+			snapshotId: parsed.snapshotId,
+			aggregateId: parsed.aggregateId,
+			registeredOn: new Date(parsed.registeredOn),
+			version: parsed.version,
 		});
+	}
+
+	private async getLastStreamEntity<A extends AggregateRoot>(
+		collection: string,
+		streamId: string,
+	): Promise<Record<string, AttributeValue>> {
+		const { Items } = await this.client.send(
+			new QueryCommand({
+				TableName: collection,
+				KeyConditionExpression: 'streamId = :streamId',
+				ExpressionAttributeValues: {
+					':streamId': { S: streamId },
+				},
+				ScanIndexForward: false,
+				Limit: 1,
+			}),
+		);
+
+		return Items.pop();
 	}
 }

--- a/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -104,9 +104,7 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		const collection = SnapshotCollection.get(pool);
 		const snapshotCollection = this.collections.get(collection) || [];
 
-		let entity = snapshotCollection.filter(({ streamId: entityStreamId }) => entityStreamId === streamId).sort(
-			({ version: currentVersion }, { version: previousVersion }) => (previousVersion < currentVersion ? -1 : 1),
-		)[0];
+		let entity = this.getLastStreamEntity<A>(snapshotCollection, streamId);
 
 		if (entity) {
 			return entity.payload;
@@ -117,9 +115,7 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		const collection = SnapshotCollection.get(pool);
 		const snapshotCollection = this.collections.get(collection) || [];
 
-		let entity = snapshotCollection.filter(({ streamId: entityStreamId }) => entityStreamId === streamId).sort(
-			({ version: currentVersion }, { version: previousVersion }) => (previousVersion < currentVersion ? -1 : 1),
-		)[0];
+		let entity = this.getLastStreamEntity<A>(snapshotCollection, streamId);
 
 		if (entity) {
 			return SnapshotEnvelope.from(entity.payload, {
@@ -227,6 +223,19 @@ export class InMemorySnapshotStore extends SnapshotStore {
 				({ payload, aggregateId, registeredOn, snapshotId, version }) =>
 					SnapshotEnvelope.from<A>(payload, { aggregateId, registeredOn, snapshotId, version }),
 			);
+		}
+	}
+
+	private getLastStreamEntity<A extends AggregateRoot>(
+		collection: InMemorySnapshotEntity<any>[],
+		streamId: string,
+	): InMemorySnapshotEntity<A> {
+		const [entity] = collection.filter(({ streamId: entityStreamId }) => entityStreamId === streamId).sort(
+			({ version: currentVersion }, { version: previousVersion }) => (previousVersion < currentVersion ? -1 : 1),
+		);
+
+		if (entity) {
+			return entity;
 		}
 	}
 }

--- a/lib/interfaces/aggregate/snapshot-handler.ts
+++ b/lib/interfaces/aggregate/snapshot-handler.ts
@@ -18,10 +18,9 @@ export abstract class SnapshotHandler<A extends AggregateRoot = AggregateRoot> {
 	}
 
 	async save(id: Id, aggregate: A, pool?: ISnapshotPool): Promise<void> {
-		if (aggregate.version % this.interval === 0) {
+		if (aggregate.version % this.interval === 0 || aggregate.version === 1) {
 			const snapshotStream = SnapshotStream.for(aggregate, id);
 			const payload = this.serialize(aggregate);
-
 			await this.snapshotStore.appendSnapshot(snapshotStream, aggregate.version, payload, pool);
 		}
 	}

--- a/lib/models/snapshot-stream.ts
+++ b/lib/models/snapshot-stream.ts
@@ -7,6 +7,10 @@ import { Id } from './id';
 export class SnapshotStream {
 	private constructor(private _aggregate: string, private _aggregateId: string) {}
 
+	get aggregate(): string {
+		return this._aggregate;
+	}
+
 	get aggregateId(): string {
 		return this._aggregateId;
 	}

--- a/lib/query-bus.ts
+++ b/lib/query-bus.ts
@@ -24,7 +24,8 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
 		const queryId = this.getQueryId(query);
 		const handler = this.handlers.get(queryId);
 		if (!handler) {
-			throw new QueryHandlerNotFoundException(queryId);
+			const { constructor: queryType } = Object.getPrototypeOf(query);
+			throw new QueryHandlerNotFoundException(queryType);
 		}
 		this._publisher.publish(query);
 		return handler.execute(query);

--- a/lib/snapshot-store.ts
+++ b/lib/snapshot-store.ts
@@ -29,6 +29,8 @@ export interface SnapshotFilter {
 	batch?: number;
 }
 
+export interface LatestSnapshotFilter extends Pick<SnapshotFilter, 'batch' | 'limit'> {}
+
 export abstract class SnapshotStore {
 	abstract setup(pool?: ISnapshotPool): SnapshotCollection | Promise<SnapshotCollection>;
 	abstract getSnapshots<A extends AggregateRoot>(
@@ -63,4 +65,9 @@ export abstract class SnapshotStore {
 		version: number,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
+	abstract getLastEnvelopes?<A extends AggregateRoot>(
+		aggregateName: string,
+		filter?: LatestSnapshotFilter,
+		pool?: ISnapshotPool,
+	): AsyncGenerator<SnapshotEnvelope<A>[]>;
 }

--- a/lib/snapshot-store.ts
+++ b/lib/snapshot-store.ts
@@ -29,7 +29,9 @@ export interface SnapshotFilter {
 	batch?: number;
 }
 
-export interface LatestSnapshotFilter extends Pick<SnapshotFilter, 'batch' | 'limit'> {}
+export interface LatestSnapshotFilter extends Pick<SnapshotFilter, 'batch' | 'limit'> {
+	fromId?: string;
+}
 
 export abstract class SnapshotStore {
 	abstract setup(pool?: ISnapshotPool): SnapshotCollection | Promise<SnapshotCollection>;

--- a/package.json
+++ b/package.json
@@ -48,8 +48,14 @@
 		}
 	},
 	"devDependencies": {
+<<<<<<< HEAD
 		"@aws-sdk/client-dynamodb": "3.186.0",
 		"@aws-sdk/util-dynamodb": "3.186.0",
+=======
+		"@aws-sdk/client-dynamodb": "3.181.0",
+		"@aws-sdk/util-dynamodb": "3.181.0",
+		"@faker-js/faker": "^7.5.0",
+>>>>>>> 1d6210b (:heavy_plus_sign: add faker as a dev dependency)
 		"@nestjs/common": "9.1.2",
 		"@nestjs/core": "9.1.2",
 		"@nestjs/platform-express": "9.1.2",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,9 @@
 		}
 	},
 	"devDependencies": {
-<<<<<<< HEAD
 		"@aws-sdk/client-dynamodb": "3.186.0",
 		"@aws-sdk/util-dynamodb": "3.186.0",
-=======
-		"@aws-sdk/client-dynamodb": "3.181.0",
-		"@aws-sdk/util-dynamodb": "3.181.0",
 		"@faker-js/faker": "^7.5.0",
->>>>>>> 1d6210b (:heavy_plus_sign: add faker as a dev dependency)
 		"@nestjs/common": "9.1.2",
 		"@nestjs/core": "9.1.2",
 		"@nestjs/platform-express": "9.1.2",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 	"scripts": {
 		"build": "rm -rf dist && tsc -p tsconfig.build.json",
 		"ci": "rome ci ./lib",
-		"format": "rome format ./lib ./tests --write",
-		"lint": "rome check ./lib ./tests --apply-suggested",
+		"format": "rome format ./lib ./tests ./example --write",
+		"lint": "rome check ./lib ./tests ./example --apply-suggested",
 		"test": "jest --config jest.config.js --runInBand",
 		"test:ci": "jest --config jest.config.js --runInBand --coverage",
 		"run:example": "node -r @swc-node/register ./example/src/main.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@aws-sdk/client-dynamodb': 3.186.0
   '@aws-sdk/util-dynamodb': 3.186.0
+  '@faker-js/faker': ^7.5.0
   '@nestjs/common': 9.1.2
   '@nestjs/core': 9.1.2
   '@nestjs/event-emitter': 1.3.1
@@ -31,6 +32,7 @@ dependencies:
 devDependencies:
   '@aws-sdk/client-dynamodb': 3.186.0
   '@aws-sdk/util-dynamodb': 3.186.0
+  '@faker-js/faker': 7.5.0
   '@nestjs/common': 9.1.2_zjqyf46x76hyng3zndsldtoema
   '@nestjs/core': 9.1.2_zzb753o6ov5n3wrhompfrkwa7u
   '@nestjs/platform-express': 9.1.2_umdjpi6fqr4wvw73r3mhthbyle
@@ -1049,6 +1051,11 @@ packages:
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@faker-js/faker/7.5.0:
+    resolution: {integrity: sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
     dev: true
 
   /@iarna/toml/2.2.5:

--- a/tests/e2e/src/app.providers.ts
+++ b/tests/e2e/src/app.providers.ts
@@ -8,6 +8,7 @@ import {
 	OpenAccountCommandHandler,
 	RemoveAccountOwnerCommandHandler,
 } from './application/commands';
+import { GetAccountByIdQueryHandler, GetAccountsQueryHandler } from './application/queries';
 import { AccountRepository } from './application/repositories';
 import {
 	AccountClosedEvent,
@@ -30,7 +31,7 @@ export const CommandHandlers: Type<ICommandHandler>[] = [
 	RemoveAccountOwnerCommandHandler,
 ];
 
-export const QueryHandlers: Type<IQueryHandler>[] = [];
+export const QueryHandlers: Type<IQueryHandler>[] = [GetAccountByIdQueryHandler, GetAccountsQueryHandler];
 
 export const SnapshotHandlers: Type<SnapshotHandler>[] = [AccountSnapshotHandler];
 

--- a/tests/e2e/src/application/account.dtos.ts
+++ b/tests/e2e/src/application/account.dtos.ts
@@ -25,7 +25,7 @@ export class AccountDto {
 		public readonly id: string,
 		public readonly ownerIds: string[],
 		public readonly balance: number,
-		public readonly openedOn: Date,
+		public readonly openedOn: string,
 	) {}
 
 	static from(account: Account): AccountDto {
@@ -33,7 +33,7 @@ export class AccountDto {
 			account.id.value,
 			account.ownerIds?.map(({ value }) => value),
 			account.balance,
-			account.openedOn,
+			account.openedOn.toISOString(),
 		);
 	}
 }

--- a/tests/e2e/src/application/queries/get-account-by-id.query.ts
+++ b/tests/e2e/src/application/queries/get-account-by-id.query.ts
@@ -1,0 +1,25 @@
+import { IQuery, IQueryHandler, QueryHandler } from '@ocoda/event-sourcing';
+import { AccountId } from '../../domain/models';
+import { AccountDto } from '../account.dtos';
+import { AccountRepository } from '../repositories';
+
+export class GetAccountByIdQuery implements IQuery {
+	constructor(public readonly accountId: string) {}
+}
+
+@QueryHandler(GetAccountByIdQuery)
+export class GetAccountByIdQueryHandler implements IQueryHandler<GetAccountByIdQuery, AccountDto> {
+	constructor(private readonly accountRepository: AccountRepository) {}
+
+	public async execute(query: GetAccountByIdQuery): Promise<AccountDto> {
+		const accountId = AccountId.from(query.accountId);
+
+		const account = await this.accountRepository.getById(accountId);
+
+		if (account.closedOn) {
+			return;
+		}
+
+		return AccountDto.from(account);
+	}
+}

--- a/tests/e2e/src/application/queries/get-accounts.query.ts
+++ b/tests/e2e/src/application/queries/get-accounts.query.ts
@@ -1,0 +1,19 @@
+import { IQuery, IQueryHandler, QueryHandler } from '@ocoda/event-sourcing';
+import { AccountId } from '../../domain/models';
+import { AccountDto } from '../account.dtos';
+import { AccountRepository } from '../repositories';
+
+export class GetAccountsQuery implements IQuery {}
+
+@QueryHandler(GetAccountsQuery)
+export class GetAccountsQueryHandler implements IQueryHandler<GetAccountsQuery, AccountDto[]> {
+	constructor(private readonly accountRepository: AccountRepository) {}
+
+	public async execute(query: GetAccountsQuery): Promise<AccountDto[]> {
+		const accounts = await this.accountRepository.getAll();
+
+		return accounts.reduce<AccountDto[]>((acc, account) => {
+			return account.closedOn ? acc : [...acc, AccountDto.from(account)];
+		}, []);
+	}
+}

--- a/tests/e2e/src/application/queries/index.ts
+++ b/tests/e2e/src/application/queries/index.ts
@@ -1,0 +1,2 @@
+export * from './get-account-by-id.query';
+export * from './get-accounts.query';

--- a/tests/unit/decorators/command-handler.decorator.spec.ts
+++ b/tests/unit/decorators/command-handler.decorator.spec.ts
@@ -1,5 +1,5 @@
-import { getCommandHandlerMetadata, getCommandMetadata } from '@ocoda/event-sourcing/helpers';
 import { CommandHandler, ICommand } from '../../../lib';
+import { getCommandHandlerMetadata, getCommandMetadata } from '../../../lib/helpers';
 
 describe('@CommandHandler', () => {
 	class TestCommand implements ICommand {}

--- a/tests/unit/decorators/event-serializer.decorator.spec.ts
+++ b/tests/unit/decorators/event-serializer.decorator.spec.ts
@@ -1,5 +1,5 @@
-import { getEventSerializerMetadata } from '@ocoda/event-sourcing/helpers';
 import { EventSerializer, IEvent } from '../../../lib';
+import { getEventSerializerMetadata } from '../../../lib/helpers';
 
 describe('@EventSerializer', () => {
 	class AccountCreatedEvent implements IEvent {}

--- a/tests/unit/decorators/event.decorator.spec.ts
+++ b/tests/unit/decorators/event.decorator.spec.ts
@@ -1,5 +1,5 @@
-import { getEventMetadata } from '@ocoda/event-sourcing/helpers';
 import { Event, IEvent } from '../../../lib';
+import { getEventMetadata } from '../../../lib/helpers';
 
 describe('@Event', () => {
 	@Event('foo-created')

--- a/tests/unit/decorators/query-handler.decorator.spec.ts
+++ b/tests/unit/decorators/query-handler.decorator.spec.ts
@@ -1,5 +1,5 @@
-import { getQueryHandlerMetadata, getQueryMetadata } from '@ocoda/event-sourcing/helpers';
 import { IQuery, QueryHandler } from '../../../lib';
+import { getQueryHandlerMetadata, getQueryMetadata } from '../../../lib/helpers';
 
 describe('@QueryHandler', () => {
 	class TestQuery implements IQuery {}

--- a/tests/unit/decorators/snapshot.decorator.spec.ts
+++ b/tests/unit/decorators/snapshot.decorator.spec.ts
@@ -1,4 +1,5 @@
 import { AggregateRoot, Snapshot, SnapshotMetadata, SNAPSHOT_METADATA } from '../../../lib';
+import { getSnapshotMetadata } from '../../../lib/helpers';
 
 describe('@Snapshot', () => {
 	class Account extends AggregateRoot {}
@@ -7,10 +8,7 @@ describe('@Snapshot', () => {
 		@Snapshot(Account, { name: "foo", interval: 20 })
 		class AccountSnapshotHandler {}
 
-		const { aggregate, name, interval }: SnapshotMetadata<Account> = Reflect.getMetadata(
-			SNAPSHOT_METADATA,
-			AccountSnapshotHandler,
-		);
+		const { aggregate, name, interval }: SnapshotMetadata<Account> = getSnapshotMetadata(AccountSnapshotHandler);
 		expect(aggregate).toEqual(Account);
 		expect(name).toEqual('foo');
 		expect(interval).toEqual(20);

--- a/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
@@ -1,10 +1,6 @@
-import {
-	DeleteTableCommand,
-	DynamoDBClient,
-	QueryCommand,
-} from "@aws-sdk/client-dynamodb";
-import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { EventEmitter2 } from "@nestjs/event-emitter";
+import { DeleteTableCommand, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -17,11 +13,11 @@ import {
 	Id,
 	IEvent,
 	StreamReadingDirection,
-} from "../../../../lib";
-import { DefaultEventSerializer } from "../../../../lib/helpers";
-import { DynamoDBEventStore } from "../../../../lib/integration/event-store";
+} from '../../../../lib';
+import { DefaultEventSerializer } from '../../../../lib/helpers';
+import { DynamoDBEventStore } from '../../../../lib/integration/event-store';
 
-jest.mock("@nestjs/event-emitter", () => {
+jest.mock('@nestjs/event-emitter', () => {
 	return {
 		EventEmitter2: jest.fn().mockImplementation(() => {
 			return { emit: () => {} };
@@ -33,10 +29,7 @@ class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(
-		private readonly id: AccountId,
-		private readonly balance: number,
-	) {
+	constructor(private readonly id: AccountId, private readonly balance: number) {
 		super();
 	}
 }
@@ -65,22 +58,10 @@ describe(DynamoDBEventStore, () => {
 	let envelopesAccountB: EventEnvelope[];
 
 	const eventMap = new EventMap();
-	eventMap.register(
-		AccountOpenedEvent,
-		DefaultEventSerializer.for(AccountOpenedEvent),
-	);
-	eventMap.register(
-		AccountCreditedEvent,
-		DefaultEventSerializer.for(AccountCreditedEvent),
-	);
-	eventMap.register(
-		AccountDebitedEvent,
-		DefaultEventSerializer.for(AccountDebitedEvent),
-	);
-	eventMap.register(
-		AccountClosedEvent,
-		DefaultEventSerializer.for(AccountClosedEvent),
-	);
+	eventMap.register(AccountOpenedEvent, DefaultEventSerializer.for(AccountOpenedEvent));
+	eventMap.register(AccountCreditedEvent, DefaultEventSerializer.for(AccountCreditedEvent));
+	eventMap.register(AccountDebitedEvent, DefaultEventSerializer.for(AccountDebitedEvent));
+	eventMap.register(AccountClosedEvent, DefaultEventSerializer.for(AccountClosedEvent));
 
 	const events = [
 		new AccountOpenedEvent(),
@@ -99,123 +80,73 @@ describe(DynamoDBEventStore, () => {
 
 	beforeAll(async () => {
 		client = new DynamoDBClient({
-			region: "us-east-1",
-			endpoint: "http://127.0.0.1:8000",
-			credentials: { accessKeyId: "foo", secretAccessKey: "bar" },
+			region: 'us-east-1',
+			endpoint: 'http://127.0.0.1:8000',
+			credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
 		});
 		eventStore = new DynamoDBEventStore(eventMap, eventEmitter, client);
 		await eventStore.setup();
 
 		envelopesAccountA = [
-			EventEnvelope.create(
-				"account-opened",
-				eventMap.serializeEvent(events[0]),
-				{
-					aggregateId: idAccountA.value,
-					version: 1,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[1]),
-				{
-					aggregateId: idAccountA.value,
-					version: 2,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[2]),
-				{
-					aggregateId: idAccountA.value,
-					version: 3,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[3]),
-				{
-					aggregateId: idAccountA.value,
-					version: 4,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[4]),
-				{
-					aggregateId: idAccountA.value,
-					version: 5,
-				},
-			),
-			EventEnvelope.create(
-				"account-closed",
-				eventMap.serializeEvent(events[5]),
-				{
-					aggregateId: idAccountA.value,
-					version: 6,
-				},
-			),
+			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+				aggregateId: idAccountA.value,
+				version: 1,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+				aggregateId: idAccountA.value,
+				version: 2,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+				aggregateId: idAccountA.value,
+				version: 3,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+				aggregateId: idAccountA.value,
+				version: 4,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+				aggregateId: idAccountA.value,
+				version: 5,
+			}),
+			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+				aggregateId: idAccountA.value,
+				version: 6,
+			}),
 		];
 		envelopesAccountB = [
-			EventEnvelope.create(
-				"account-opened",
-				eventMap.serializeEvent(events[0]),
-				{
-					aggregateId: idAccountB.value,
-					version: 1,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[1]),
-				{
-					aggregateId: idAccountB.value,
-					version: 2,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[2]),
-				{
-					aggregateId: idAccountB.value,
-					version: 3,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[3]),
-				{
-					aggregateId: idAccountB.value,
-					version: 4,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[4]),
-				{
-					aggregateId: idAccountB.value,
-					version: 5,
-				},
-			),
-			EventEnvelope.create(
-				"account-closed",
-				eventMap.serializeEvent(events[5]),
-				{
-					aggregateId: idAccountB.value,
-					version: 6,
-				},
-			),
+			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+				aggregateId: idAccountB.value,
+				version: 1,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+				aggregateId: idAccountB.value,
+				version: 2,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+				aggregateId: idAccountB.value,
+				version: 3,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+				aggregateId: idAccountB.value,
+				version: 4,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+				aggregateId: idAccountB.value,
+				version: 5,
+			}),
+			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+				aggregateId: idAccountB.value,
+				version: 6,
+			}),
 		];
 	});
 
 	afterAll(async () => {
-		await client.send(
-			new DeleteTableCommand({ TableName: EventCollection.get() }),
-		);
+		await client.send(new DeleteTableCommand({ TableName: EventCollection.get() }));
 		client.destroy();
 	});
 
-	it("should append event envelopes", async () => {
+	it('should append event envelopes', async () => {
 		await Promise.all([
 			eventStore.appendEvents(eventStreamAccountA, 3, events.slice(0, 3)),
 			eventStore.appendEvents(eventStreamAccountB, 3, events.slice(0, 3)),
@@ -226,26 +157,24 @@ describe(DynamoDBEventStore, () => {
 		const { Items: itemsAccountA } = await client.send(
 			new QueryCommand({
 				TableName: EventCollection.get(),
-				KeyConditionExpression: "streamId = :streamId",
+				KeyConditionExpression: 'streamId = :streamId',
 				ExpressionAttributeValues: {
-					":streamId": { S: eventStreamAccountA.streamId },
+					':streamId': { S: eventStreamAccountA.streamId },
 				},
 			}),
 		);
-		const entitiesAccountA =
-			itemsAccountA?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountA = itemsAccountA?.map((item) => unmarshall(item)) || [];
 
 		const { Items: itemsAccountB } = await client.send(
 			new QueryCommand({
 				TableName: EventCollection.get(),
-				KeyConditionExpression: "streamId = :streamId",
+				KeyConditionExpression: 'streamId = :streamId',
 				ExpressionAttributeValues: {
-					":streamId": { S: eventStreamAccountB.streamId },
+					':streamId': { S: eventStreamAccountB.streamId },
 				},
 			}),
 		);
-		const entitiesAccountB =
-			itemsAccountB?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountB = itemsAccountB?.map((item) => unmarshall(item)) || [];
 
 		expect(entitiesAccountA).toHaveLength(events.length);
 		expect(entitiesAccountB).toHaveLength(events.length);
@@ -254,10 +183,8 @@ describe(DynamoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountA.streamId);
 			expect(entity.event).toEqual(envelopesAccountA[index].event);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
-			expect(typeof entity.occurredOn).toBe("number");
+			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(typeof entity.occurredOn).toBe('number');
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 
@@ -265,24 +192,19 @@ describe(DynamoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountB.streamId);
 			expect(entity.event).toEqual(envelopesAccountB[index].event);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountB[index].metadata.aggregateId,
-			);
-			expect(typeof entity.occurredOn).toBe("number");
+			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
+			expect(typeof entity.occurredOn).toBe('number');
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it("should retrieve a single event from a specified stream", async () => {
-		const resolvedEvent = await eventStore.getEvent(
-			eventStreamAccountA,
-			envelopesAccountA[3].metadata.version,
-		);
+	it('should retrieve a single event from a specified stream', async () => {
+		const resolvedEvent = await eventStore.getEvent(eventStreamAccountA, envelopesAccountA[3].metadata.version);
 
 		expect(resolvedEvent).toEqual(events[3]);
 	});
 
-	it("should filter events by stream", async () => {
+	it('should filter events by stream', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA)) {
 			resolvedEvents.push(...events);
@@ -291,7 +213,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it("should filter events by stream and version", async () => {
+	it('should filter events by stream and version', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 3,
@@ -304,12 +226,10 @@ describe(DynamoDBEventStore, () => {
 
 	it("should throw when an event isn't found in a specified stream", async () => {
 		const stream = EventStream.for(Account, AccountId.generate());
-		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(
-			new EventNotFoundException(stream.streamId, 5),
-		);
+		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(new EventNotFoundException(stream.streamId, 5));
 	});
 
-	it("should retrieve events backwards", async () => {
+	it('should retrieve events backwards', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			direction: StreamReadingDirection.BACKWARD,
@@ -320,7 +240,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice().reverse());
 	});
 
-	it("should retrieve events backwards from a certain version", async () => {
+	it('should retrieve events backwards from a certain version', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 4,
@@ -332,7 +252,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(3).reverse());
 	});
 
-	it("should limit the returned events", async () => {
+	it('should limit the returned events', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			limit: 3,
@@ -343,7 +263,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(0, 3));
 	});
 
-	it("should batch the returned events", async () => {
+	it('should batch the returned events', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			batch: 2,
@@ -355,7 +275,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it("should retrieve a single event-envelope", async () => {
+	it('should retrieve a single event-envelope', async () => {
 		const { event, metadata, payload } = await eventStore.getEnvelope(
 			eventStreamAccountA,
 			envelopesAccountA[3].metadata.version,
@@ -363,18 +283,14 @@ describe(DynamoDBEventStore, () => {
 
 		expect(event).toEqual(envelopesAccountA[3].event);
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(
-			envelopesAccountA[3].metadata.aggregateId,
-		);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
 		expect(metadata.occurredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it("should retrieve event-envelopes", async () => {
+	it('should retrieve event-envelopes', async () => {
 		const resolvedEnvelopes: EventEnvelope[] = [];
-		for await (const envelopes of eventStore.getEnvelopes(
-			eventStreamAccountA,
-		)) {
+		for await (const envelopes of eventStore.getEnvelopes(eventStreamAccountA)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -383,13 +299,9 @@ describe(DynamoDBEventStore, () => {
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.event).toEqual(envelopesAccountA[index].event);
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
 			expect(envelope.metadata.occurredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(
-				envelopesAccountA[index].metadata.version,
-			);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
 });

--- a/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
@@ -1,6 +1,10 @@
-import { DeleteTableCommand, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
-import { unmarshall } from '@aws-sdk/util-dynamodb';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+	DeleteTableCommand,
+	DynamoDBClient,
+	QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import {
 	Aggregate,
 	AggregateRoot,
@@ -13,11 +17,11 @@ import {
 	Id,
 	IEvent,
 	StreamReadingDirection,
-} from '../../../../lib';
-import { DefaultEventSerializer } from '../../../../lib/helpers';
-import { DynamoDBEventStore } from '../../../../lib/integration/event-store';
+} from "../../../../lib";
+import { DefaultEventSerializer } from "../../../../lib/helpers";
+import { DynamoDBEventStore } from "../../../../lib/integration/event-store";
 
-jest.mock('@nestjs/event-emitter', () => {
+jest.mock("@nestjs/event-emitter", () => {
 	return {
 		EventEmitter2: jest.fn().mockImplementation(() => {
 			return { emit: () => {} };
@@ -29,7 +33,10 @@ class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(private readonly id: AccountId, private readonly balance: number) {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
 		super();
 	}
 }
@@ -58,10 +65,22 @@ describe(DynamoDBEventStore, () => {
 	let envelopesAccountB: EventEnvelope[];
 
 	const eventMap = new EventMap();
-	eventMap.register(AccountOpenedEvent, DefaultEventSerializer.for(AccountOpenedEvent));
-	eventMap.register(AccountCreditedEvent, DefaultEventSerializer.for(AccountCreditedEvent));
-	eventMap.register(AccountDebitedEvent, DefaultEventSerializer.for(AccountDebitedEvent));
-	eventMap.register(AccountClosedEvent, DefaultEventSerializer.for(AccountClosedEvent));
+	eventMap.register(
+		AccountOpenedEvent,
+		DefaultEventSerializer.for(AccountOpenedEvent),
+	);
+	eventMap.register(
+		AccountCreditedEvent,
+		DefaultEventSerializer.for(AccountCreditedEvent),
+	);
+	eventMap.register(
+		AccountDebitedEvent,
+		DefaultEventSerializer.for(AccountDebitedEvent),
+	);
+	eventMap.register(
+		AccountClosedEvent,
+		DefaultEventSerializer.for(AccountClosedEvent),
+	);
 
 	const events = [
 		new AccountOpenedEvent(),
@@ -80,73 +99,123 @@ describe(DynamoDBEventStore, () => {
 
 	beforeAll(async () => {
 		client = new DynamoDBClient({
-			region: 'us-east-1',
-			endpoint: 'http://localhost:8000',
-			credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
+			region: "us-east-1",
+			endpoint: "http://127.0.0.1:8000",
+			credentials: { accessKeyId: "foo", secretAccessKey: "bar" },
 		});
 		eventStore = new DynamoDBEventStore(eventMap, eventEmitter, client);
 		await eventStore.setup();
 
 		envelopesAccountA = [
-			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
-				aggregateId: idAccountA.value,
-				version: 1,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
-				aggregateId: idAccountA.value,
-				version: 2,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
-				aggregateId: idAccountA.value,
-				version: 3,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
-				aggregateId: idAccountA.value,
-				version: 4,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
-				aggregateId: idAccountA.value,
-				version: 5,
-			}),
-			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
-				aggregateId: idAccountA.value,
-				version: 6,
-			}),
+			EventEnvelope.create(
+				"account-opened",
+				eventMap.serializeEvent(events[0]),
+				{
+					aggregateId: idAccountA.value,
+					version: 1,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[1]),
+				{
+					aggregateId: idAccountA.value,
+					version: 2,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[2]),
+				{
+					aggregateId: idAccountA.value,
+					version: 3,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[3]),
+				{
+					aggregateId: idAccountA.value,
+					version: 4,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[4]),
+				{
+					aggregateId: idAccountA.value,
+					version: 5,
+				},
+			),
+			EventEnvelope.create(
+				"account-closed",
+				eventMap.serializeEvent(events[5]),
+				{
+					aggregateId: idAccountA.value,
+					version: 6,
+				},
+			),
 		];
 		envelopesAccountB = [
-			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
-				aggregateId: idAccountB.value,
-				version: 1,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
-				aggregateId: idAccountB.value,
-				version: 2,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
-				aggregateId: idAccountB.value,
-				version: 3,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
-				aggregateId: idAccountB.value,
-				version: 4,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
-				aggregateId: idAccountB.value,
-				version: 5,
-			}),
-			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
-				aggregateId: idAccountB.value,
-				version: 6,
-			}),
+			EventEnvelope.create(
+				"account-opened",
+				eventMap.serializeEvent(events[0]),
+				{
+					aggregateId: idAccountB.value,
+					version: 1,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[1]),
+				{
+					aggregateId: idAccountB.value,
+					version: 2,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[2]),
+				{
+					aggregateId: idAccountB.value,
+					version: 3,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[3]),
+				{
+					aggregateId: idAccountB.value,
+					version: 4,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[4]),
+				{
+					aggregateId: idAccountB.value,
+					version: 5,
+				},
+			),
+			EventEnvelope.create(
+				"account-closed",
+				eventMap.serializeEvent(events[5]),
+				{
+					aggregateId: idAccountB.value,
+					version: 6,
+				},
+			),
 		];
 	});
 
 	afterAll(async () => {
-		await client.send(new DeleteTableCommand({ TableName: EventCollection.get() }));
+		await client.send(
+			new DeleteTableCommand({ TableName: EventCollection.get() }),
+		);
 		client.destroy();
 	});
 
-	it('should append event envelopes', async () => {
+	it("should append event envelopes", async () => {
 		await Promise.all([
 			eventStore.appendEvents(eventStreamAccountA, 3, events.slice(0, 3)),
 			eventStore.appendEvents(eventStreamAccountB, 3, events.slice(0, 3)),
@@ -157,24 +226,26 @@ describe(DynamoDBEventStore, () => {
 		const { Items: itemsAccountA } = await client.send(
 			new QueryCommand({
 				TableName: EventCollection.get(),
-				KeyConditionExpression: 'streamId = :streamId',
+				KeyConditionExpression: "streamId = :streamId",
 				ExpressionAttributeValues: {
-					':streamId': { S: eventStreamAccountA.streamId },
+					":streamId": { S: eventStreamAccountA.streamId },
 				},
 			}),
 		);
-		const entitiesAccountA = itemsAccountA?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountA =
+			itemsAccountA?.map((item) => unmarshall(item)) || [];
 
 		const { Items: itemsAccountB } = await client.send(
 			new QueryCommand({
 				TableName: EventCollection.get(),
-				KeyConditionExpression: 'streamId = :streamId',
+				KeyConditionExpression: "streamId = :streamId",
 				ExpressionAttributeValues: {
-					':streamId': { S: eventStreamAccountB.streamId },
+					":streamId": { S: eventStreamAccountB.streamId },
 				},
 			}),
 		);
-		const entitiesAccountB = itemsAccountB?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountB =
+			itemsAccountB?.map((item) => unmarshall(item)) || [];
 
 		expect(entitiesAccountA).toHaveLength(events.length);
 		expect(entitiesAccountB).toHaveLength(events.length);
@@ -183,8 +254,10 @@ describe(DynamoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountA.streamId);
 			expect(entity.event).toEqual(envelopesAccountA[index].event);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
-			expect(typeof entity.occurredOn).toBe('number');
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
+			expect(typeof entity.occurredOn).toBe("number");
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 
@@ -192,19 +265,24 @@ describe(DynamoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountB.streamId);
 			expect(entity.event).toEqual(envelopesAccountB[index].event);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
-			expect(typeof entity.occurredOn).toBe('number');
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountB[index].metadata.aggregateId,
+			);
+			expect(typeof entity.occurredOn).toBe("number");
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it('should retrieve a single event from a specified stream', async () => {
-		const resolvedEvent = await eventStore.getEvent(eventStreamAccountA, envelopesAccountA[3].metadata.version);
+	it("should retrieve a single event from a specified stream", async () => {
+		const resolvedEvent = await eventStore.getEvent(
+			eventStreamAccountA,
+			envelopesAccountA[3].metadata.version,
+		);
 
 		expect(resolvedEvent).toEqual(events[3]);
 	});
 
-	it('should filter events by stream', async () => {
+	it("should filter events by stream", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA)) {
 			resolvedEvents.push(...events);
@@ -213,9 +291,11 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it('should filter events by stream and version', async () => {
+	it("should filter events by stream and version", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { fromVersion: 3 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			fromVersion: 3,
+		})) {
 			resolvedEvents.push(...events);
 		}
 
@@ -224,10 +304,12 @@ describe(DynamoDBEventStore, () => {
 
 	it("should throw when an event isn't found in a specified stream", async () => {
 		const stream = EventStream.for(Account, AccountId.generate());
-		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(new EventNotFoundException(stream.streamId, 5));
+		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(
+			new EventNotFoundException(stream.streamId, 5),
+		);
 	});
 
-	it('should retrieve events backwards', async () => {
+	it("should retrieve events backwards", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			direction: StreamReadingDirection.BACKWARD,
@@ -238,7 +320,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice().reverse());
 	});
 
-	it('should retrieve events backwards from a certain version', async () => {
+	it("should retrieve events backwards from a certain version", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 4,
@@ -250,18 +332,22 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(3).reverse());
 	});
 
-	it('should limit the returned events', async () => {
+	it("should limit the returned events", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { limit: 3 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			limit: 3,
+		})) {
 			resolvedEvents.push(...events);
 		}
 
 		expect(resolvedEvents).toEqual(events.slice(0, 3));
 	});
 
-	it('should batch the returned events', async () => {
+	it("should batch the returned events", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { batch: 2 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			batch: 2,
+		})) {
 			expect(events.length).toBe(2);
 			resolvedEvents.push(...events);
 		}
@@ -269,7 +355,7 @@ describe(DynamoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it('should retrieve a single event-envelope', async () => {
+	it("should retrieve a single event-envelope", async () => {
 		const { event, metadata, payload } = await eventStore.getEnvelope(
 			eventStreamAccountA,
 			envelopesAccountA[3].metadata.version,
@@ -277,14 +363,18 @@ describe(DynamoDBEventStore, () => {
 
 		expect(event).toEqual(envelopesAccountA[3].event);
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.aggregateId).toEqual(
+			envelopesAccountA[3].metadata.aggregateId,
+		);
 		expect(metadata.occurredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it('should retrieve event-envelopes', async () => {
+	it("should retrieve event-envelopes", async () => {
 		const resolvedEnvelopes: EventEnvelope[] = [];
-		for await (const envelopes of eventStore.getEnvelopes(eventStreamAccountA)) {
+		for await (const envelopes of eventStore.getEnvelopes(
+			eventStreamAccountA,
+		)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -293,9 +383,13 @@ describe(DynamoDBEventStore, () => {
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.event).toEqual(envelopesAccountA[index].event);
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(envelope.metadata.occurredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+			expect(envelope.metadata.version).toEqual(
+				envelopesAccountA[index].metadata.version,
+			);
 		});
 	});
 });

--- a/tests/unit/integration/event-store/mongodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/mongodb.event-store.spec.ts
@@ -1,5 +1,5 @@
-import { EventEmitter2 } from "@nestjs/event-emitter";
-import { MongoClient } from "mongodb";
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { MongoClient } from 'mongodb';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -12,14 +12,11 @@ import {
 	Id,
 	IEvent,
 	StreamReadingDirection,
-} from "../../../../lib";
-import { DefaultEventSerializer } from "../../../../lib/helpers";
-import {
-	MongoDBEventStore,
-	MongoEventEntity,
-} from "../../../../lib/integration/event-store";
+} from '../../../../lib';
+import { DefaultEventSerializer } from '../../../../lib/helpers';
+import { MongoDBEventStore, MongoEventEntity } from '../../../../lib/integration/event-store';
 
-jest.mock("@nestjs/event-emitter", () => {
+jest.mock('@nestjs/event-emitter', () => {
 	return {
 		EventEmitter2: jest.fn().mockImplementation(() => {
 			return { emit: () => {} };
@@ -31,10 +28,7 @@ class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(
-		private readonly id: AccountId,
-		private readonly balance: number,
-	) {
+	constructor(private readonly id: AccountId, private readonly balance: number) {
 		super();
 	}
 }
@@ -63,22 +57,10 @@ describe(MongoDBEventStore, () => {
 	let envelopesAccountB: EventEnvelope[];
 
 	const eventMap = new EventMap();
-	eventMap.register(
-		AccountOpenedEvent,
-		DefaultEventSerializer.for(AccountOpenedEvent),
-	);
-	eventMap.register(
-		AccountCreditedEvent,
-		DefaultEventSerializer.for(AccountCreditedEvent),
-	);
-	eventMap.register(
-		AccountDebitedEvent,
-		DefaultEventSerializer.for(AccountDebitedEvent),
-	);
-	eventMap.register(
-		AccountClosedEvent,
-		DefaultEventSerializer.for(AccountClosedEvent),
-	);
+	eventMap.register(AccountOpenedEvent, DefaultEventSerializer.for(AccountOpenedEvent));
+	eventMap.register(AccountCreditedEvent, DefaultEventSerializer.for(AccountCreditedEvent));
+	eventMap.register(AccountDebitedEvent, DefaultEventSerializer.for(AccountDebitedEvent));
+	eventMap.register(AccountClosedEvent, DefaultEventSerializer.for(AccountClosedEvent));
 
 	const events = [
 		new AccountOpenedEvent(),
@@ -96,109 +78,61 @@ describe(MongoDBEventStore, () => {
 	const eventStreamAccountB = EventStream.for(Account, idAccountB);
 
 	beforeAll(async () => {
-		client = new MongoClient("mongodb://127.0.0.1:27017");
+		client = new MongoClient('mongodb://127.0.0.1:27017');
 		eventStore = new MongoDBEventStore(eventMap, eventEmitter, client.db());
 		await eventStore.setup();
 
 		envelopesAccountA = [
-			EventEnvelope.create(
-				"account-opened",
-				eventMap.serializeEvent(events[0]),
-				{
-					aggregateId: idAccountA.value,
-					version: 1,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[1]),
-				{
-					aggregateId: idAccountA.value,
-					version: 2,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[2]),
-				{
-					aggregateId: idAccountA.value,
-					version: 3,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[3]),
-				{
-					aggregateId: idAccountA.value,
-					version: 4,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[4]),
-				{
-					aggregateId: idAccountA.value,
-					version: 5,
-				},
-			),
-			EventEnvelope.create(
-				"account-closed",
-				eventMap.serializeEvent(events[5]),
-				{
-					aggregateId: idAccountA.value,
-					version: 6,
-				},
-			),
+			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+				aggregateId: idAccountA.value,
+				version: 1,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+				aggregateId: idAccountA.value,
+				version: 2,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+				aggregateId: idAccountA.value,
+				version: 3,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+				aggregateId: idAccountA.value,
+				version: 4,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+				aggregateId: idAccountA.value,
+				version: 5,
+			}),
+			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+				aggregateId: idAccountA.value,
+				version: 6,
+			}),
 		];
 		envelopesAccountB = [
-			EventEnvelope.create(
-				"account-opened",
-				eventMap.serializeEvent(events[0]),
-				{
-					aggregateId: idAccountB.value,
-					version: 1,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[1]),
-				{
-					aggregateId: idAccountB.value,
-					version: 2,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[2]),
-				{
-					aggregateId: idAccountB.value,
-					version: 3,
-				},
-			),
-			EventEnvelope.create(
-				"account-credited",
-				eventMap.serializeEvent(events[3]),
-				{
-					aggregateId: idAccountB.value,
-					version: 4,
-				},
-			),
-			EventEnvelope.create(
-				"account-debited",
-				eventMap.serializeEvent(events[4]),
-				{
-					aggregateId: idAccountB.value,
-					version: 5,
-				},
-			),
-			EventEnvelope.create(
-				"account-closed",
-				eventMap.serializeEvent(events[5]),
-				{
-					aggregateId: idAccountB.value,
-					version: 6,
-				},
-			),
+			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+				aggregateId: idAccountB.value,
+				version: 1,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+				aggregateId: idAccountB.value,
+				version: 2,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+				aggregateId: idAccountB.value,
+				version: 3,
+			}),
+			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+				aggregateId: idAccountB.value,
+				version: 4,
+			}),
+			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+				aggregateId: idAccountB.value,
+				version: 5,
+			}),
+			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+				aggregateId: idAccountB.value,
+				version: 6,
+			}),
 		];
 	});
 
@@ -207,7 +141,7 @@ describe(MongoDBEventStore, () => {
 		await client.close();
 	});
 
-	it("should append event envelopes", async () => {
+	it('should append event envelopes', async () => {
 		await Promise.all([
 			eventStore.appendEvents(eventStreamAccountA, 3, events.slice(0, 3)),
 			eventStore.appendEvents(eventStreamAccountB, 3, events.slice(0, 3)),
@@ -223,12 +157,10 @@ describe(MongoDBEventStore, () => {
 			.toArray();
 
 		const entitiesAccountA = entities.filter(
-			({ streamId: entityStreamId }) =>
-				entityStreamId === eventStreamAccountA.streamId,
+			({ streamId: entityStreamId }) => entityStreamId === eventStreamAccountA.streamId,
 		);
 		const entitiesAccountB = entities.filter(
-			({ streamId: entityStreamId }) =>
-				entityStreamId === eventStreamAccountB.streamId,
+			({ streamId: entityStreamId }) => entityStreamId === eventStreamAccountB.streamId,
 		);
 
 		expect(entities).toHaveLength(events.length * 2);
@@ -239,9 +171,7 @@ describe(MongoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountA.streamId);
 			expect(entity.event).toEqual(envelopesAccountA[index].event);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
+			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
 			expect(entity.occurredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
@@ -250,24 +180,19 @@ describe(MongoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountB.streamId);
 			expect(entity.event).toEqual(envelopesAccountB[index].event);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountB[index].metadata.aggregateId,
-			);
+			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
 			expect(entity.occurredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it("should retrieve a single event from a specified stream", async () => {
-		const resolvedEvent = await eventStore.getEvent(
-			eventStreamAccountA,
-			envelopesAccountA[3].metadata.version,
-		);
+	it('should retrieve a single event from a specified stream', async () => {
+		const resolvedEvent = await eventStore.getEvent(eventStreamAccountA, envelopesAccountA[3].metadata.version);
 
 		expect(resolvedEvent).toEqual(events[3]);
 	});
 
-	it("should filter events by stream", async () => {
+	it('should filter events by stream', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA)) {
 			resolvedEvents.push(...events);
@@ -276,7 +201,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it("should filter events by stream and version", async () => {
+	it('should filter events by stream and version', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 3,
@@ -289,12 +214,10 @@ describe(MongoDBEventStore, () => {
 
 	it("should throw when an event isn't found in a specified stream", async () => {
 		const stream = EventStream.for(Account, AccountId.generate());
-		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(
-			new EventNotFoundException(stream.streamId, 5),
-		);
+		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(new EventNotFoundException(stream.streamId, 5));
 	});
 
-	it("should retrieve events backwards", async () => {
+	it('should retrieve events backwards', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			direction: StreamReadingDirection.BACKWARD,
@@ -305,7 +228,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice().reverse());
 	});
 
-	it("should retrieve events backwards from a certain version", async () => {
+	it('should retrieve events backwards from a certain version', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 4,
@@ -317,7 +240,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(3).reverse());
 	});
 
-	it("should limit the returned events", async () => {
+	it('should limit the returned events', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			limit: 3,
@@ -328,7 +251,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(0, 3));
 	});
 
-	it("should batch the returned events", async () => {
+	it('should batch the returned events', async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			batch: 2,
@@ -340,7 +263,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it("should retrieve a single event-envelope", async () => {
+	it('should retrieve a single event-envelope', async () => {
 		const { event, metadata, payload } = await eventStore.getEnvelope(
 			eventStreamAccountA,
 			envelopesAccountA[3].metadata.version,
@@ -348,18 +271,14 @@ describe(MongoDBEventStore, () => {
 
 		expect(event).toEqual(envelopesAccountA[3].event);
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(
-			envelopesAccountA[3].metadata.aggregateId,
-		);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
 		expect(metadata.occurredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it("should retrieve event-envelopes", async () => {
+	it('should retrieve event-envelopes', async () => {
 		const resolvedEnvelopes: EventEnvelope[] = [];
-		for await (const envelopes of eventStore.getEnvelopes(
-			eventStreamAccountA,
-		)) {
+		for await (const envelopes of eventStore.getEnvelopes(eventStreamAccountA)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -368,13 +287,9 @@ describe(MongoDBEventStore, () => {
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.event).toEqual(envelopesAccountA[index].event);
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
 			expect(envelope.metadata.occurredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(
-				envelopesAccountA[index].metadata.version,
-			);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
 });

--- a/tests/unit/integration/event-store/mongodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/mongodb.event-store.spec.ts
@@ -1,5 +1,5 @@
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { MongoClient } from 'mongodb';
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { MongoClient } from "mongodb";
 import {
 	Aggregate,
 	AggregateRoot,
@@ -12,11 +12,14 @@ import {
 	Id,
 	IEvent,
 	StreamReadingDirection,
-} from '../../../../lib';
-import { DefaultEventSerializer } from '../../../../lib/helpers';
-import { MongoDBEventStore, MongoEventEntity } from '../../../../lib/integration/event-store';
+} from "../../../../lib";
+import { DefaultEventSerializer } from "../../../../lib/helpers";
+import {
+	MongoDBEventStore,
+	MongoEventEntity,
+} from "../../../../lib/integration/event-store";
 
-jest.mock('@nestjs/event-emitter', () => {
+jest.mock("@nestjs/event-emitter", () => {
 	return {
 		EventEmitter2: jest.fn().mockImplementation(() => {
 			return { emit: () => {} };
@@ -28,7 +31,10 @@ class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(private readonly id: AccountId, private readonly balance: number) {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
 		super();
 	}
 }
@@ -57,10 +63,22 @@ describe(MongoDBEventStore, () => {
 	let envelopesAccountB: EventEnvelope[];
 
 	const eventMap = new EventMap();
-	eventMap.register(AccountOpenedEvent, DefaultEventSerializer.for(AccountOpenedEvent));
-	eventMap.register(AccountCreditedEvent, DefaultEventSerializer.for(AccountCreditedEvent));
-	eventMap.register(AccountDebitedEvent, DefaultEventSerializer.for(AccountDebitedEvent));
-	eventMap.register(AccountClosedEvent, DefaultEventSerializer.for(AccountClosedEvent));
+	eventMap.register(
+		AccountOpenedEvent,
+		DefaultEventSerializer.for(AccountOpenedEvent),
+	);
+	eventMap.register(
+		AccountCreditedEvent,
+		DefaultEventSerializer.for(AccountCreditedEvent),
+	);
+	eventMap.register(
+		AccountDebitedEvent,
+		DefaultEventSerializer.for(AccountDebitedEvent),
+	);
+	eventMap.register(
+		AccountClosedEvent,
+		DefaultEventSerializer.for(AccountClosedEvent),
+	);
 
 	const events = [
 		new AccountOpenedEvent(),
@@ -78,61 +96,109 @@ describe(MongoDBEventStore, () => {
 	const eventStreamAccountB = EventStream.for(Account, idAccountB);
 
 	beforeAll(async () => {
-		client = new MongoClient('mongodb://localhost:27017');
+		client = new MongoClient("mongodb://127.0.0.1:27017");
 		eventStore = new MongoDBEventStore(eventMap, eventEmitter, client.db());
 		await eventStore.setup();
 
 		envelopesAccountA = [
-			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
-				aggregateId: idAccountA.value,
-				version: 1,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
-				aggregateId: idAccountA.value,
-				version: 2,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
-				aggregateId: idAccountA.value,
-				version: 3,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
-				aggregateId: idAccountA.value,
-				version: 4,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
-				aggregateId: idAccountA.value,
-				version: 5,
-			}),
-			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
-				aggregateId: idAccountA.value,
-				version: 6,
-			}),
+			EventEnvelope.create(
+				"account-opened",
+				eventMap.serializeEvent(events[0]),
+				{
+					aggregateId: idAccountA.value,
+					version: 1,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[1]),
+				{
+					aggregateId: idAccountA.value,
+					version: 2,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[2]),
+				{
+					aggregateId: idAccountA.value,
+					version: 3,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[3]),
+				{
+					aggregateId: idAccountA.value,
+					version: 4,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[4]),
+				{
+					aggregateId: idAccountA.value,
+					version: 5,
+				},
+			),
+			EventEnvelope.create(
+				"account-closed",
+				eventMap.serializeEvent(events[5]),
+				{
+					aggregateId: idAccountA.value,
+					version: 6,
+				},
+			),
 		];
 		envelopesAccountB = [
-			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
-				aggregateId: idAccountB.value,
-				version: 1,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
-				aggregateId: idAccountB.value,
-				version: 2,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
-				aggregateId: idAccountB.value,
-				version: 3,
-			}),
-			EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
-				aggregateId: idAccountB.value,
-				version: 4,
-			}),
-			EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
-				aggregateId: idAccountB.value,
-				version: 5,
-			}),
-			EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
-				aggregateId: idAccountB.value,
-				version: 6,
-			}),
+			EventEnvelope.create(
+				"account-opened",
+				eventMap.serializeEvent(events[0]),
+				{
+					aggregateId: idAccountB.value,
+					version: 1,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[1]),
+				{
+					aggregateId: idAccountB.value,
+					version: 2,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[2]),
+				{
+					aggregateId: idAccountB.value,
+					version: 3,
+				},
+			),
+			EventEnvelope.create(
+				"account-credited",
+				eventMap.serializeEvent(events[3]),
+				{
+					aggregateId: idAccountB.value,
+					version: 4,
+				},
+			),
+			EventEnvelope.create(
+				"account-debited",
+				eventMap.serializeEvent(events[4]),
+				{
+					aggregateId: idAccountB.value,
+					version: 5,
+				},
+			),
+			EventEnvelope.create(
+				"account-closed",
+				eventMap.serializeEvent(events[5]),
+				{
+					aggregateId: idAccountB.value,
+					version: 6,
+				},
+			),
 		];
 	});
 
@@ -141,7 +207,7 @@ describe(MongoDBEventStore, () => {
 		await client.close();
 	});
 
-	it('should append event envelopes', async () => {
+	it("should append event envelopes", async () => {
 		await Promise.all([
 			eventStore.appendEvents(eventStreamAccountA, 3, events.slice(0, 3)),
 			eventStore.appendEvents(eventStreamAccountB, 3, events.slice(0, 3)),
@@ -157,10 +223,12 @@ describe(MongoDBEventStore, () => {
 			.toArray();
 
 		const entitiesAccountA = entities.filter(
-			({ streamId: entityStreamId }) => entityStreamId === eventStreamAccountA.streamId,
+			({ streamId: entityStreamId }) =>
+				entityStreamId === eventStreamAccountA.streamId,
 		);
 		const entitiesAccountB = entities.filter(
-			({ streamId: entityStreamId }) => entityStreamId === eventStreamAccountB.streamId,
+			({ streamId: entityStreamId }) =>
+				entityStreamId === eventStreamAccountB.streamId,
 		);
 
 		expect(entities).toHaveLength(events.length * 2);
@@ -171,7 +239,9 @@ describe(MongoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountA.streamId);
 			expect(entity.event).toEqual(envelopesAccountA[index].event);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(entity.occurredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
@@ -180,19 +250,24 @@ describe(MongoDBEventStore, () => {
 			expect(entity.streamId).toEqual(eventStreamAccountB.streamId);
 			expect(entity.event).toEqual(envelopesAccountB[index].event);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountB[index].metadata.aggregateId,
+			);
 			expect(entity.occurredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it('should retrieve a single event from a specified stream', async () => {
-		const resolvedEvent = await eventStore.getEvent(eventStreamAccountA, envelopesAccountA[3].metadata.version);
+	it("should retrieve a single event from a specified stream", async () => {
+		const resolvedEvent = await eventStore.getEvent(
+			eventStreamAccountA,
+			envelopesAccountA[3].metadata.version,
+		);
 
 		expect(resolvedEvent).toEqual(events[3]);
 	});
 
-	it('should filter events by stream', async () => {
+	it("should filter events by stream", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA)) {
 			resolvedEvents.push(...events);
@@ -201,9 +276,11 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it('should filter events by stream and version', async () => {
+	it("should filter events by stream and version", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { fromVersion: 3 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			fromVersion: 3,
+		})) {
 			resolvedEvents.push(...events);
 		}
 
@@ -212,10 +289,12 @@ describe(MongoDBEventStore, () => {
 
 	it("should throw when an event isn't found in a specified stream", async () => {
 		const stream = EventStream.for(Account, AccountId.generate());
-		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(new EventNotFoundException(stream.streamId, 5));
+		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(
+			new EventNotFoundException(stream.streamId, 5),
+		);
 	});
 
-	it('should retrieve events backwards', async () => {
+	it("should retrieve events backwards", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			direction: StreamReadingDirection.BACKWARD,
@@ -226,7 +305,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice().reverse());
 	});
 
-	it('should retrieve events backwards from a certain version', async () => {
+	it("should retrieve events backwards from a certain version", async () => {
 		const resolvedEvents: IEvent[] = [];
 		for await (const events of eventStore.getEvents(eventStreamAccountA, {
 			fromVersion: 4,
@@ -238,18 +317,22 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events.slice(3).reverse());
 	});
 
-	it('should limit the returned events', async () => {
+	it("should limit the returned events", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { limit: 3 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			limit: 3,
+		})) {
 			resolvedEvents.push(...events);
 		}
 
 		expect(resolvedEvents).toEqual(events.slice(0, 3));
 	});
 
-	it('should batch the returned events', async () => {
+	it("should batch the returned events", async () => {
 		const resolvedEvents: IEvent[] = [];
-		for await (const events of eventStore.getEvents(eventStreamAccountA, { batch: 2 })) {
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			batch: 2,
+		})) {
 			expect(events.length).toBe(2);
 			resolvedEvents.push(...events);
 		}
@@ -257,7 +340,7 @@ describe(MongoDBEventStore, () => {
 		expect(resolvedEvents).toEqual(events);
 	});
 
-	it('should retrieve a single event-envelope', async () => {
+	it("should retrieve a single event-envelope", async () => {
 		const { event, metadata, payload } = await eventStore.getEnvelope(
 			eventStreamAccountA,
 			envelopesAccountA[3].metadata.version,
@@ -265,14 +348,18 @@ describe(MongoDBEventStore, () => {
 
 		expect(event).toEqual(envelopesAccountA[3].event);
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.aggregateId).toEqual(
+			envelopesAccountA[3].metadata.aggregateId,
+		);
 		expect(metadata.occurredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it('should retrieve event-envelopes', async () => {
+	it("should retrieve event-envelopes", async () => {
 		const resolvedEnvelopes: EventEnvelope[] = [];
-		for await (const envelopes of eventStore.getEnvelopes(eventStreamAccountA)) {
+		for await (const envelopes of eventStore.getEnvelopes(
+			eventStreamAccountA,
+		)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -281,9 +368,13 @@ describe(MongoDBEventStore, () => {
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.event).toEqual(envelopesAccountA[index].event);
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(envelope.metadata.occurredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+			expect(envelope.metadata.version).toEqual(
+				envelopesAccountA[index].metadata.version,
+			);
 		});
 	});
 });

--- a/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
@@ -1,9 +1,5 @@
-import {
-	DeleteTableCommand,
-	DynamoDBClient,
-	QueryCommand,
-} from "@aws-sdk/client-dynamodb";
-import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { DeleteTableCommand, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -14,17 +10,22 @@ import {
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
-} from "../../../../lib";
-import { DynamoDBSnapshotStore } from "../../../../lib/integration/snapshot-store";
+} from '../../../../lib';
+import { DynamoDBSnapshotStore } from '../../../../lib/integration/snapshot-store';
 
 class AccountId extends Id {}
+class CustomerId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(
-		private readonly id: AccountId,
-		private readonly balance: number,
-	) {
+	constructor(private readonly id: AccountId, private readonly balance: number) {
+		super();
+	}
+}
+
+@Aggregate({ streamName: 'customer' })
+class Customer extends AggregateRoot {
+	constructor(private readonly id: CustomerId, private readonly name: string) {
 		super();
 	}
 }
@@ -35,256 +36,235 @@ describe(DynamoDBSnapshotStore, () => {
 	let envelopesAccountA: SnapshotEnvelope[];
 	let envelopesAccountB: SnapshotEnvelope[];
 
-	const snapshots: ISnapshot<Account>[] = [
+	const idAccountA = AccountId.generate();
+	const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
+	const snapshotsAccountA: ISnapshot<Account>[] = [
+		{ balance: 0 },
 		{ balance: 50 },
 		{ balance: 20 },
 		{ balance: 60 },
 		{ balance: 50 },
 	];
 
-	const idAccountA = AccountId.generate();
 	const idAccountB = AccountId.generate();
-	const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
 	const snapshotStreamAccountB = SnapshotStream.for(Account, idAccountB);
+	const snapshotsAccountB: ISnapshot<Account>[] = [{ balance: 0 }, { balance: 10 }, { balance: 20 }, { balance: 30 }];
+
+	const customerSnapshot: ISnapshot<Customer> = { name: 'Hubert Farnsworth' };
+
+	const customerId = CustomerId.generate();
+	const snapshotStreamCustomer = SnapshotStream.for(Customer, customerId);
 
 	beforeAll(async () => {
 		client = new DynamoDBClient({
-			region: "us-east-1",
-			endpoint: "http://127.0.0.1:8000",
-			credentials: { accessKeyId: "foo", secretAccessKey: "bar" },
+			region: 'us-east-1',
+			endpoint: 'http://127.0.0.1:8000',
+			credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
 		});
 		snapshotStore = new DynamoDBSnapshotStore(client);
 		await snapshotStore.setup();
 
 		envelopesAccountA = [
-			SnapshotEnvelope.create<Account>(snapshots[0], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[0], {
+				aggregateId: idAccountA.value,
+				version: 1,
+			}),
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[1], {
 				aggregateId: idAccountA.value,
 				version: 10,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[1], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[2], {
 				aggregateId: idAccountA.value,
 				version: 20,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[2], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[3], {
 				aggregateId: idAccountA.value,
 				version: 30,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[3], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[4], {
 				aggregateId: idAccountA.value,
 				version: 40,
 			}),
 		];
 		envelopesAccountB = [
-			SnapshotEnvelope.create<Account>(snapshots[0], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[0], {
+				aggregateId: idAccountB.value,
+				version: 1,
+			}),
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[1], {
 				aggregateId: idAccountB.value,
 				version: 10,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[1], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[2], {
 				aggregateId: idAccountB.value,
 				version: 20,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[2], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[3], {
 				aggregateId: idAccountB.value,
 				version: 30,
-			}),
-			SnapshotEnvelope.create<Account>(snapshots[3], {
-				aggregateId: idAccountB.value,
-				version: 40,
 			}),
 		];
 	});
 
 	afterAll(async () => {
-		await client.send(
-			new DeleteTableCommand({ TableName: SnapshotCollection.get() }),
-		);
+		await client.send(new DeleteTableCommand({ TableName: SnapshotCollection.get() }));
 		client.destroy();
 	});
 
-	it("should append snapshot envelopes", async () => {
-		await Promise.all([
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshots[0]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshots[0]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 20, snapshots[1]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 20, snapshots[1]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 30, snapshots[2]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 30, snapshots[2]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 40, snapshots[3]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 40, snapshots[3]),
-		]);
+	it('should append snapshot envelopes', async () => {
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 1, snapshotsAccountA[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 1, snapshotsAccountB[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshotsAccountA[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshotsAccountB[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 20, snapshotsAccountA[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 20, snapshotsAccountB[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 30, snapshotsAccountA[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 30, snapshotsAccountB[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 40, snapshotsAccountA[4]);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 1, customerSnapshot);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 10, customerSnapshot);
 
 		const { Items: itemsAccountA } = await client.send(
 			new QueryCommand({
 				TableName: SnapshotCollection.get(),
-				KeyConditionExpression: "streamId = :streamId",
+				KeyConditionExpression: 'streamId = :streamId',
 				ExpressionAttributeValues: {
-					":streamId": { S: snapshotStreamAccountA.streamId },
+					':streamId': { S: snapshotStreamAccountA.streamId },
 				},
 			}),
 		);
-		const entitiesAccountA =
-			itemsAccountA?.map((item) => unmarshall(item)) || [];
+
+		const entitiesAccountA = itemsAccountA?.map((item) => unmarshall(item)) || [];
 
 		const { Items: itemsAccountB } = await client.send(
 			new QueryCommand({
 				TableName: SnapshotCollection.get(),
-				KeyConditionExpression: "streamId = :streamId",
+				KeyConditionExpression: 'streamId = :streamId',
 				ExpressionAttributeValues: {
-					":streamId": { S: snapshotStreamAccountB.streamId },
+					':streamId': { S: snapshotStreamAccountB.streamId },
 				},
 			}),
 		);
-		const entitiesAccountB =
-			itemsAccountB?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountB = itemsAccountB?.map((item) => unmarshall(item)) || [];
 
-		expect(entitiesAccountA).toHaveLength(snapshots.length);
-		expect(entitiesAccountB).toHaveLength(snapshots.length);
+		const { Items: itemsCustomer } = await client.send(
+			new QueryCommand({
+				TableName: SnapshotCollection.get(),
+				KeyConditionExpression: 'streamId = :streamId',
+				ExpressionAttributeValues: {
+					':streamId': { S: snapshotStreamCustomer.streamId },
+				},
+			}),
+		);
+		const entitiesCustomer = itemsCustomer?.map((item) => unmarshall(item)) || [];
+
+		expect(entitiesAccountA).toHaveLength(snapshotsAccountA.length);
+		expect(entitiesAccountB).toHaveLength(snapshotsAccountB.length);
+		expect(entitiesCustomer).toHaveLength(2);
 
 		entitiesAccountA.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
-			expect(typeof entity.registeredOn).toBe("number");
+			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(typeof entity.registeredOn).toBe('number');
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
-
-		entitiesAccountB.forEach((entity, index) => {
-			expect(entity.streamId).toEqual(snapshotStreamAccountB.streamId);
-			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountB[index].metadata.aggregateId,
-			);
-			expect(typeof entity.registeredOn).toBe("number");
-			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
-		});
 	});
 
-	it("should retrieve a single snapshot from a specified stream", async () => {
+	it('should retrieve a single snapshot from a specified stream', async () => {
 		const resolvedSnapshot = await snapshotStore.getSnapshot(
 			snapshotStreamAccountA,
-			envelopesAccountA[1].metadata.version,
+			envelopesAccountA[2].metadata.version,
 		);
 
-		expect(resolvedSnapshot).toEqual(snapshots[1]);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[2]);
 	});
 
-	it("should retrieve snapshots by stream", async () => {
+	it('should retrieve snapshots by stream', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots);
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA);
 	});
 
-	it("should filter snapshots by stream and version", async () => {
+	it('should filter snapshots by stream and version', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{ fromVersion: 30 },
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { fromVersion: 30 })) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(3));
 	});
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {
 		const stream = SnapshotStream.for(Account, AccountId.generate());
-		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(
-			new SnapshotNotFoundException(stream.streamId, 20),
-		);
+		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(new SnapshotNotFoundException(stream.streamId, 20));
 	});
 
-	it("should retrieve snapshots backwards", async () => {
+	it('should retrieve snapshots backwards', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{
-				direction: StreamReadingDirection.BACKWARD,
-			},
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice().reverse());
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice().reverse());
 	});
 
-	it("should retrieve snapshots backwards from a certain version", async () => {
+	it('should retrieve snapshots backwards from a certain version', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{
-				fromVersion: envelopesAccountA[1].metadata.version,
-				direction: StreamReadingDirection.BACKWARD,
-			},
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			fromVersion: envelopesAccountA[1].metadata.version,
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(
-			snapshots
-				.filter(
-					(_, index) =>
-						(index + 1) * 10 >= envelopesAccountA[1].metadata.version,
-				)
-				.reverse(),
+			snapshotsAccountA.filter((_, index) => (index + 1) * 10 >= envelopesAccountA[2].metadata.version).reverse(),
 		);
 	});
 
-	it("should limit the returned snapshots", async () => {
+	it('should limit the returned snapshots', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{ limit: 2 },
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
 	});
 
-	it("should batch the returned snapshots", async () => {
+	it('should batch the returned snapshots', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{ limit: 2 },
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
 			expect(snapshots.length).toBe(2);
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
 	});
 
-	it("should retrieve the last snapshot", async () => {
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
-			snapshotStreamAccountA,
-		);
+	it('should retrieve the last snapshot', async () => {
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(snapshotStreamAccountA);
 
-		expect(resolvedSnapshot).toEqual(snapshots[snapshots.length - 1]);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
 	});
 
-	it("should return undefined if there is no last snapshot", async () => {
+	it('should return undefined if there is no last snapshot', async () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
-			SnapshotStream.for(Foo, Id.generate()),
-		);
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
-	it("should retrieve snapshot-envelopes", async () => {
+	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getEnvelopes(
-			snapshotStreamAccountA,
-		)) {
+		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -292,39 +272,57 @@ describe(DynamoDBSnapshotStore, () => {
 
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
 			expect(envelope.metadata.registeredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(
-				envelopesAccountA[index].metadata.version,
-			);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
 
-	it("should retrieve a single snapshot-envelope", async () => {
+	it('should retrieve a single snapshot-envelope', async () => {
 		const { metadata, payload } = await snapshotStore.getEnvelope(
 			snapshotStreamAccountA,
 			envelopesAccountA[3].metadata.version,
 		);
 
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(
-			envelopesAccountA[3].metadata.aggregateId,
-		);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it("should retrieve the last snapshot-envelope", async () => {
+	it('should retrieve the last snapshot-envelope', async () => {
 		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = await snapshotStore.getLastEnvelope(
-			snapshotStreamAccountA,
-		);
+		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
 
 		expect(payload).toEqual(lastEnvelope.payload);
 		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
+	});
+
+	it('should retrieve the last snapshot-envelopes', async () => {
+		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+			resolvedEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedEnvelopes).toHaveLength(2);
+
+		const [envelopeAccountB, envelopeAccountA] = [
+			envelopesAccountB[envelopesAccountB.length - 1],
+			envelopesAccountA[envelopesAccountA.length - 1],
+		];
+
+		resolvedEnvelopes = resolvedEnvelopes.sort((a, b) => (a.metadata.version > b.metadata.version ? 1 : -1));
+
+		expect(resolvedEnvelopes[0].payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedEnvelopes[0].metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedEnvelopes[0].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[0].metadata.version).toEqual(envelopeAccountB.metadata.version);
+
+		expect(resolvedEnvelopes[1].payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
 	});
 });

--- a/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
@@ -1,5 +1,9 @@
-import { DeleteTableCommand, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
-import { unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+	DeleteTableCommand,
+	DynamoDBClient,
+	QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
 import {
 	Aggregate,
 	AggregateRoot,
@@ -10,14 +14,17 @@ import {
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
-} from '../../../../lib';
-import { DynamoDBSnapshotStore } from '../../../../lib/integration/snapshot-store';
+} from "../../../../lib";
+import { DynamoDBSnapshotStore } from "../../../../lib/integration/snapshot-store";
 
 class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(private readonly id: AccountId, private readonly balance: number) {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
 		super();
 	}
 }
@@ -28,7 +35,12 @@ describe(DynamoDBSnapshotStore, () => {
 	let envelopesAccountA: SnapshotEnvelope[];
 	let envelopesAccountB: SnapshotEnvelope[];
 
-	const snapshots: ISnapshot<Account>[] = [{ balance: 50 }, { balance: 20 }, { balance: 60 }, { balance: 50 }];
+	const snapshots: ISnapshot<Account>[] = [
+		{ balance: 50 },
+		{ balance: 20 },
+		{ balance: 60 },
+		{ balance: 50 },
+	];
 
 	const idAccountA = AccountId.generate();
 	const idAccountB = AccountId.generate();
@@ -37,33 +49,59 @@ describe(DynamoDBSnapshotStore, () => {
 
 	beforeAll(async () => {
 		client = new DynamoDBClient({
-			region: 'us-east-1',
-			endpoint: 'http://localhost:8000',
-			credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
+			region: "us-east-1",
+			endpoint: "http://127.0.0.1:8000",
+			credentials: { accessKeyId: "foo", secretAccessKey: "bar" },
 		});
 		snapshotStore = new DynamoDBSnapshotStore(client);
 		await snapshotStore.setup();
 
 		envelopesAccountA = [
-			SnapshotEnvelope.create<Account>(snapshots[0], { aggregateId: idAccountA.value, version: 10 }),
-			SnapshotEnvelope.create<Account>(snapshots[1], { aggregateId: idAccountA.value, version: 20 }),
-			SnapshotEnvelope.create<Account>(snapshots[2], { aggregateId: idAccountA.value, version: 30 }),
-			SnapshotEnvelope.create<Account>(snapshots[3], { aggregateId: idAccountA.value, version: 40 }),
+			SnapshotEnvelope.create<Account>(snapshots[0], {
+				aggregateId: idAccountA.value,
+				version: 10,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[1], {
+				aggregateId: idAccountA.value,
+				version: 20,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[2], {
+				aggregateId: idAccountA.value,
+				version: 30,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[3], {
+				aggregateId: idAccountA.value,
+				version: 40,
+			}),
 		];
 		envelopesAccountB = [
-			SnapshotEnvelope.create<Account>(snapshots[0], { aggregateId: idAccountB.value, version: 10 }),
-			SnapshotEnvelope.create<Account>(snapshots[1], { aggregateId: idAccountB.value, version: 20 }),
-			SnapshotEnvelope.create<Account>(snapshots[2], { aggregateId: idAccountB.value, version: 30 }),
-			SnapshotEnvelope.create<Account>(snapshots[3], { aggregateId: idAccountB.value, version: 40 }),
+			SnapshotEnvelope.create<Account>(snapshots[0], {
+				aggregateId: idAccountB.value,
+				version: 10,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[1], {
+				aggregateId: idAccountB.value,
+				version: 20,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[2], {
+				aggregateId: idAccountB.value,
+				version: 30,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[3], {
+				aggregateId: idAccountB.value,
+				version: 40,
+			}),
 		];
 	});
 
 	afterAll(async () => {
-		await client.send(new DeleteTableCommand({ TableName: SnapshotCollection.get() }));
+		await client.send(
+			new DeleteTableCommand({ TableName: SnapshotCollection.get() }),
+		);
 		client.destroy();
 	});
 
-	it('should append snapshot envelopes', async () => {
+	it("should append snapshot envelopes", async () => {
 		await Promise.all([
 			snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshots[0]),
 			snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshots[0]),
@@ -78,24 +116,26 @@ describe(DynamoDBSnapshotStore, () => {
 		const { Items: itemsAccountA } = await client.send(
 			new QueryCommand({
 				TableName: SnapshotCollection.get(),
-				KeyConditionExpression: 'streamId = :streamId',
+				KeyConditionExpression: "streamId = :streamId",
 				ExpressionAttributeValues: {
-					':streamId': { S: snapshotStreamAccountA.streamId },
+					":streamId": { S: snapshotStreamAccountA.streamId },
 				},
 			}),
 		);
-		const entitiesAccountA = itemsAccountA?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountA =
+			itemsAccountA?.map((item) => unmarshall(item)) || [];
 
 		const { Items: itemsAccountB } = await client.send(
 			new QueryCommand({
 				TableName: SnapshotCollection.get(),
-				KeyConditionExpression: 'streamId = :streamId',
+				KeyConditionExpression: "streamId = :streamId",
 				ExpressionAttributeValues: {
-					':streamId': { S: snapshotStreamAccountB.streamId },
+					":streamId": { S: snapshotStreamAccountB.streamId },
 				},
 			}),
 		);
-		const entitiesAccountB = itemsAccountB?.map((item) => unmarshall(item)) || [];
+		const entitiesAccountB =
+			itemsAccountB?.map((item) => unmarshall(item)) || [];
 
 		expect(entitiesAccountA).toHaveLength(snapshots.length);
 		expect(entitiesAccountB).toHaveLength(snapshots.length);
@@ -103,21 +143,25 @@ describe(DynamoDBSnapshotStore, () => {
 		entitiesAccountA.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
-			expect(typeof entity.registeredOn).toBe('number');
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
+			expect(typeof entity.registeredOn).toBe("number");
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 
 		entitiesAccountB.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountB.streamId);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
-			expect(typeof entity.registeredOn).toBe('number');
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountB[index].metadata.aggregateId,
+			);
+			expect(typeof entity.registeredOn).toBe("number");
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it('should retrieve a single snapshot from a specified stream', async () => {
+	it("should retrieve a single snapshot from a specified stream", async () => {
 		const resolvedSnapshot = await snapshotStore.getSnapshot(
 			snapshotStreamAccountA,
 			envelopesAccountA[1].metadata.version,
@@ -126,18 +170,23 @@ describe(DynamoDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toEqual(snapshots[1]);
 	});
 
-	it('should retrieve snapshots by stream', async () => {
+	it("should retrieve snapshots by stream", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA)) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots);
 	});
 
-	it('should filter snapshots by stream and version', async () => {
+	it("should filter snapshots by stream and version", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { fromVersion: 30 })) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{ fromVersion: 30 },
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
@@ -146,46 +195,65 @@ describe(DynamoDBSnapshotStore, () => {
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {
 		const stream = SnapshotStream.for(Account, AccountId.generate());
-		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(new SnapshotNotFoundException(stream.streamId, 20));
+		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(
+			new SnapshotNotFoundException(stream.streamId, 20),
+		);
 	});
 
-	it('should retrieve snapshots backwards', async () => {
+	it("should retrieve snapshots backwards", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
-			direction: StreamReadingDirection.BACKWARD,
-		})) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{
+				direction: StreamReadingDirection.BACKWARD,
+			},
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots.slice().reverse());
 	});
 
-	it('should retrieve snapshots backwards from a certain version', async () => {
+	it("should retrieve snapshots backwards from a certain version", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
-			fromVersion: envelopesAccountA[1].metadata.version,
-			direction: StreamReadingDirection.BACKWARD,
-		})) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{
+				fromVersion: envelopesAccountA[1].metadata.version,
+				direction: StreamReadingDirection.BACKWARD,
+			},
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(
-			snapshots.filter((_, index) => (index + 1) * 10 >= envelopesAccountA[1].metadata.version).reverse(),
+			snapshots
+				.filter(
+					(_, index) =>
+						(index + 1) * 10 >= envelopesAccountA[1].metadata.version,
+				)
+				.reverse(),
 		);
 	});
 
-	it('should limit the returned snapshots', async () => {
+	it("should limit the returned snapshots", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{ limit: 2 },
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
 	});
 
-	it('should batch the returned snapshots', async () => {
+	it("should batch the returned snapshots", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{ limit: 2 },
+		)) {
 			expect(snapshots.length).toBe(2);
 			resolvedSnapshots.push(...snapshots);
 		}
@@ -193,24 +261,30 @@ describe(DynamoDBSnapshotStore, () => {
 		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
 	});
 
-	it('should retrieve the last snapshot', async () => {
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(snapshotStreamAccountA);
+	it("should retrieve the last snapshot", async () => {
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
+			snapshotStreamAccountA,
+		);
 
 		expect(resolvedSnapshot).toEqual(snapshots[snapshots.length - 1]);
 	});
 
-	it('should return undefined if there is no last snapshot', async () => {
+	it("should return undefined if there is no last snapshot", async () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
+			SnapshotStream.for(Foo, Id.generate()),
+		);
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
-	it('should retrieve snapshot-envelopes', async () => {
+	it("should retrieve snapshot-envelopes", async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {
+		for await (const envelopes of snapshotStore.getEnvelopes(
+			snapshotStreamAccountA,
+		)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -218,27 +292,35 @@ describe(DynamoDBSnapshotStore, () => {
 
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(envelope.metadata.registeredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+			expect(envelope.metadata.version).toEqual(
+				envelopesAccountA[index].metadata.version,
+			);
 		});
 	});
 
-	it('should retrieve a single snapshot-envelope', async () => {
+	it("should retrieve a single snapshot-envelope", async () => {
 		const { metadata, payload } = await snapshotStore.getEnvelope(
 			snapshotStreamAccountA,
 			envelopesAccountA[3].metadata.version,
 		);
 
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.aggregateId).toEqual(
+			envelopesAccountA[3].metadata.aggregateId,
+		);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelope', async () => {
+	it("should retrieve the last snapshot-envelope", async () => {
 		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
+		const { metadata, payload } = await snapshotStore.getLastEnvelope(
+			snapshotStreamAccountA,
+		);
 
 		expect(payload).toEqual(lastEnvelope.payload);
 		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);

--- a/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -129,7 +129,7 @@ describe(InMemorySnapshotStore, () => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
 			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
-			expect(typeof entity.registeredOn).toBe('number');
+			expect(entity.registeredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
@@ -155,7 +155,7 @@ describe(InMemorySnapshotStore, () => {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(3));
 	});
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {

--- a/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
@@ -1,4 +1,4 @@
-import { MongoClient } from 'mongodb';
+import { MongoClient } from "mongodb";
 import {
 	Aggregate,
 	AggregateRoot,
@@ -9,14 +9,20 @@ import {
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
-} from '../../../../lib';
-import { MongoDBSnapshotStore, MongoSnapshotEntity } from '../../../../lib/integration/snapshot-store';
+} from "../../../../lib";
+import {
+	MongoDBSnapshotStore,
+	MongoSnapshotEntity,
+} from "../../../../lib/integration/snapshot-store";
 
 class AccountId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(private readonly id: AccountId, private readonly balance: number) {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
 		super();
 	}
 }
@@ -27,7 +33,12 @@ describe(MongoDBSnapshotStore, () => {
 	let envelopesAccountA: SnapshotEnvelope[];
 	let envelopesAccountB: SnapshotEnvelope[];
 
-	const snapshots: ISnapshot<Account>[] = [{ balance: 50 }, { balance: 20 }, { balance: 60 }, { balance: 50 }];
+	const snapshots: ISnapshot<Account>[] = [
+		{ balance: 50 },
+		{ balance: 20 },
+		{ balance: 60 },
+		{ balance: 50 },
+	];
 
 	const idAccountA = AccountId.generate();
 	const idAccountB = AccountId.generate();
@@ -35,21 +46,45 @@ describe(MongoDBSnapshotStore, () => {
 	const snapshotStreamAccountB = SnapshotStream.for(Account, idAccountB);
 
 	beforeAll(async () => {
-		client = new MongoClient('mongodb://localhost:27017');
+		client = new MongoClient("mongodb://127.0.0.1:27017");
 		snapshotStore = new MongoDBSnapshotStore(client.db());
 		await snapshotStore.setup();
 
 		envelopesAccountA = [
-			SnapshotEnvelope.create<Account>(snapshots[0], { aggregateId: idAccountA.value, version: 10 }),
-			SnapshotEnvelope.create<Account>(snapshots[1], { aggregateId: idAccountA.value, version: 20 }),
-			SnapshotEnvelope.create<Account>(snapshots[2], { aggregateId: idAccountA.value, version: 30 }),
-			SnapshotEnvelope.create<Account>(snapshots[3], { aggregateId: idAccountA.value, version: 40 }),
+			SnapshotEnvelope.create<Account>(snapshots[0], {
+				aggregateId: idAccountA.value,
+				version: 10,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[1], {
+				aggregateId: idAccountA.value,
+				version: 20,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[2], {
+				aggregateId: idAccountA.value,
+				version: 30,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[3], {
+				aggregateId: idAccountA.value,
+				version: 40,
+			}),
 		];
 		envelopesAccountB = [
-			SnapshotEnvelope.create<Account>(snapshots[0], { aggregateId: idAccountB.value, version: 10 }),
-			SnapshotEnvelope.create<Account>(snapshots[1], { aggregateId: idAccountB.value, version: 20 }),
-			SnapshotEnvelope.create<Account>(snapshots[2], { aggregateId: idAccountB.value, version: 30 }),
-			SnapshotEnvelope.create<Account>(snapshots[3], { aggregateId: idAccountB.value, version: 40 }),
+			SnapshotEnvelope.create<Account>(snapshots[0], {
+				aggregateId: idAccountB.value,
+				version: 10,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[1], {
+				aggregateId: idAccountB.value,
+				version: 20,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[2], {
+				aggregateId: idAccountB.value,
+				version: 30,
+			}),
+			SnapshotEnvelope.create<Account>(snapshots[3], {
+				aggregateId: idAccountB.value,
+				version: 40,
+			}),
 		];
 	});
 
@@ -58,7 +93,7 @@ describe(MongoDBSnapshotStore, () => {
 		await client.close();
 	});
 
-	it('should append snapshot envelopes', async () => {
+	it("should append snapshot envelopes", async () => {
 		await Promise.all([
 			snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshots[0]),
 			snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshots[0]),
@@ -78,10 +113,12 @@ describe(MongoDBSnapshotStore, () => {
 			.toArray();
 
 		const entitiesAccountA = entities.filter(
-			({ streamId: entityStreamId }) => entityStreamId === snapshotStreamAccountA.streamId,
+			({ streamId: entityStreamId }) =>
+				entityStreamId === snapshotStreamAccountA.streamId,
 		);
 		const entitiesAccountB = entities.filter(
-			({ streamId: entityStreamId }) => entityStreamId === snapshotStreamAccountB.streamId,
+			({ streamId: entityStreamId }) =>
+				entityStreamId === snapshotStreamAccountB.streamId,
 		);
 
 		expect(entities).toHaveLength(snapshots.length * 2);
@@ -91,7 +128,9 @@ describe(MongoDBSnapshotStore, () => {
 		entitiesAccountA.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(entity.registeredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
@@ -99,13 +138,15 @@ describe(MongoDBSnapshotStore, () => {
 		entitiesAccountB.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountB.streamId);
 			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(envelopesAccountB[index].metadata.aggregateId);
+			expect(entity.aggregateId).toEqual(
+				envelopesAccountB[index].metadata.aggregateId,
+			);
 			expect(entity.registeredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it('should retrieve a single snapshot from a specified stream', async () => {
+	it("should retrieve a single snapshot from a specified stream", async () => {
 		const resolvedSnapshot = await snapshotStore.getSnapshot(
 			snapshotStreamAccountA,
 			envelopesAccountA[1].metadata.version,
@@ -114,20 +155,25 @@ describe(MongoDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toEqual(snapshots[1]);
 	});
 
-	it('should retrieve snapshots by stream', async () => {
+	it("should retrieve snapshots by stream", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA)) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots);
 	});
 
-	it('should filter snapshots by stream and version', async () => {
+	it("should filter snapshots by stream and version", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
-			fromVersion: 30,
-		})) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{
+				fromVersion: 30,
+			},
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
@@ -136,46 +182,65 @@ describe(MongoDBSnapshotStore, () => {
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {
 		const stream = SnapshotStream.for(Account, AccountId.generate());
-		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(new SnapshotNotFoundException(stream.streamId, 20));
+		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(
+			new SnapshotNotFoundException(stream.streamId, 20),
+		);
 	});
 
-	it('should retrieve snapshots backwards', async () => {
+	it("should retrieve snapshots backwards", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
-			direction: StreamReadingDirection.BACKWARD,
-		})) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{
+				direction: StreamReadingDirection.BACKWARD,
+			},
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots.slice().reverse());
 	});
 
-	it('should retrieve snapshots backwards from a certain version', async () => {
+	it("should retrieve snapshots backwards from a certain version", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
-			fromVersion: envelopesAccountA[1].metadata.version,
-			direction: StreamReadingDirection.BACKWARD,
-		})) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{
+				fromVersion: envelopesAccountA[1].metadata.version,
+				direction: StreamReadingDirection.BACKWARD,
+			},
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(
-			snapshots.filter((_, index) => (index + 1) * 10 >= envelopesAccountA[1].metadata.version).reverse(),
+			snapshots
+				.filter(
+					(_, index) =>
+						(index + 1) * 10 >= envelopesAccountA[1].metadata.version,
+				)
+				.reverse(),
 		);
 	});
 
-	it('should limit the returned snapshots', async () => {
+	it("should limit the returned snapshots", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{ limit: 2 },
+		)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
 	});
 
-	it('should batch the returned snapshots', async () => {
+	it("should batch the returned snapshots", async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+		for await (const snapshots of snapshotStore.getSnapshots(
+			snapshotStreamAccountA,
+			{ limit: 2 },
+		)) {
 			expect(snapshots.length).toBe(2);
 			resolvedSnapshots.push(...snapshots);
 		}
@@ -183,24 +248,30 @@ describe(MongoDBSnapshotStore, () => {
 		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
 	});
 
-	it('should retrieve the last snapshot', async () => {
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(snapshotStreamAccountA);
+	it("should retrieve the last snapshot", async () => {
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
+			snapshotStreamAccountA,
+		);
 
 		expect(resolvedSnapshot).toEqual(snapshots[snapshots.length - 1]);
 	});
 
-	it('should return undefined if there is no last snapshot', async () => {
+	it("should return undefined if there is no last snapshot", async () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
+			SnapshotStream.for(Foo, Id.generate()),
+		);
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
-	it('should retrieve snapshot-envelopes', async () => {
+	it("should retrieve snapshot-envelopes", async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {
+		for await (const envelopes of snapshotStore.getEnvelopes(
+			snapshotStreamAccountA,
+		)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -208,27 +279,35 @@ describe(MongoDBSnapshotStore, () => {
 
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.aggregateId).toEqual(
+				envelopesAccountA[index].metadata.aggregateId,
+			);
 			expect(envelope.metadata.registeredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+			expect(envelope.metadata.version).toEqual(
+				envelopesAccountA[index].metadata.version,
+			);
 		});
 	});
 
-	it('should retrieve a single snapshot-envelope', async () => {
+	it("should retrieve a single snapshot-envelope", async () => {
 		const { metadata, payload } = await snapshotStore.getEnvelope(
 			snapshotStreamAccountA,
 			envelopesAccountA[3].metadata.version,
 		);
 
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.aggregateId).toEqual(
+			envelopesAccountA[3].metadata.aggregateId,
+		);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelope', async () => {
+	it("should retrieve the last snapshot-envelope", async () => {
 		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
+		const { metadata, payload } = await snapshotStore.getLastEnvelope(
+			snapshotStreamAccountA,
+		);
 
 		expect(payload).toEqual(lastEnvelope.payload);
 		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);

--- a/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
@@ -1,4 +1,4 @@
-import { MongoClient } from "mongodb";
+import { MongoClient } from 'mongodb';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -9,20 +9,22 @@ import {
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
-} from "../../../../lib";
-import {
-	MongoDBSnapshotStore,
-	MongoSnapshotEntity,
-} from "../../../../lib/integration/snapshot-store";
+} from '../../../../lib';
+import { MongoDBSnapshotStore, MongoSnapshotEntity } from '../../../../lib/integration/snapshot-store';
 
 class AccountId extends Id {}
+class CustomerId extends Id {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
-	constructor(
-		private readonly id: AccountId,
-		private readonly balance: number,
-	) {
+	constructor(private readonly id: AccountId, private readonly balance: number) {
+		super();
+	}
+}
+
+@Aggregate({ streamName: 'customer' })
+class Customer extends AggregateRoot {
+	constructor(private readonly id: CustomerId, private readonly name: string) {
 		super();
 	}
 }
@@ -33,57 +35,68 @@ describe(MongoDBSnapshotStore, () => {
 	let envelopesAccountA: SnapshotEnvelope[];
 	let envelopesAccountB: SnapshotEnvelope[];
 
-	const snapshots: ISnapshot<Account>[] = [
+	const idAccountA = AccountId.generate();
+	const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
+	const snapshotsAccountA: ISnapshot<Account>[] = [
+		{ balance: 0 },
 		{ balance: 50 },
 		{ balance: 20 },
 		{ balance: 60 },
 		{ balance: 50 },
 	];
 
-	const idAccountA = AccountId.generate();
 	const idAccountB = AccountId.generate();
-	const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
 	const snapshotStreamAccountB = SnapshotStream.for(Account, idAccountB);
+	const snapshotsAccountB: ISnapshot<Account>[] = [{ balance: 0 }, { balance: 10 }, { balance: 20 }, { balance: 30 }];
+
+	const customerSnapshot: ISnapshot<Customer> = { name: 'Hubert Farnsworth' };
+
+	const customerId = CustomerId.generate();
+	const snapshotStreamCustomer = SnapshotStream.for(Customer, customerId);
 
 	beforeAll(async () => {
-		client = new MongoClient("mongodb://127.0.0.1:27017");
+		client = new MongoClient('mongodb://127.0.0.1:27017');
 		snapshotStore = new MongoDBSnapshotStore(client.db());
 		await snapshotStore.setup();
 
 		envelopesAccountA = [
-			SnapshotEnvelope.create<Account>(snapshots[0], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[0], {
+				aggregateId: idAccountA.value,
+				version: 1,
+			}),
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[1], {
 				aggregateId: idAccountA.value,
 				version: 10,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[1], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[2], {
 				aggregateId: idAccountA.value,
 				version: 20,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[2], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[3], {
 				aggregateId: idAccountA.value,
 				version: 30,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[3], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountA[4], {
 				aggregateId: idAccountA.value,
 				version: 40,
 			}),
 		];
 		envelopesAccountB = [
-			SnapshotEnvelope.create<Account>(snapshots[0], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[0], {
+				aggregateId: idAccountB.value,
+				version: 1,
+			}),
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[1], {
 				aggregateId: idAccountB.value,
 				version: 10,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[1], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[2], {
 				aggregateId: idAccountB.value,
 				version: 20,
 			}),
-			SnapshotEnvelope.create<Account>(snapshots[2], {
+			SnapshotEnvelope.create<Account>(snapshotsAccountB[3], {
 				aggregateId: idAccountB.value,
 				version: 30,
-			}),
-			SnapshotEnvelope.create<Account>(snapshots[3], {
-				aggregateId: idAccountB.value,
-				version: 40,
 			}),
 		];
 	});
@@ -93,17 +106,18 @@ describe(MongoDBSnapshotStore, () => {
 		await client.close();
 	});
 
-	it("should append snapshot envelopes", async () => {
-		await Promise.all([
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshots[0]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshots[0]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 20, snapshots[1]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 20, snapshots[1]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 30, snapshots[2]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 30, snapshots[2]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountA, 40, snapshots[3]),
-			snapshotStore.appendSnapshot(snapshotStreamAccountB, 40, snapshots[3]),
-		]);
+	it('should append snapshot envelopes', async () => {
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 1, snapshotsAccountA[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 1, snapshotsAccountB[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshotsAccountA[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshotsAccountB[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 20, snapshotsAccountA[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 20, snapshotsAccountB[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 30, snapshotsAccountA[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 30, snapshotsAccountB[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 40, snapshotsAccountA[4]);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 1, customerSnapshot);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 10, customerSnapshot);
 
 		const entities = await client
 			.db()
@@ -113,165 +127,124 @@ describe(MongoDBSnapshotStore, () => {
 			.toArray();
 
 		const entitiesAccountA = entities.filter(
-			({ streamId: entityStreamId }) =>
-				entityStreamId === snapshotStreamAccountA.streamId,
+			({ streamId: entityStreamId }) => entityStreamId === snapshotStreamAccountA.streamId,
 		);
 		const entitiesAccountB = entities.filter(
-			({ streamId: entityStreamId }) =>
-				entityStreamId === snapshotStreamAccountB.streamId,
+			({ streamId: entityStreamId }) => entityStreamId === snapshotStreamAccountB.streamId,
+		);
+		const entitiesCustomer = entities.filter(
+			({ streamId: entityStreamId }) => entityStreamId === snapshotStreamCustomer.streamId,
 		);
 
-		expect(entities).toHaveLength(snapshots.length * 2);
-		expect(entitiesAccountA).toHaveLength(snapshots.length);
-		expect(entitiesAccountB).toHaveLength(snapshots.length);
+		expect(entitiesAccountA).toHaveLength(snapshotsAccountA.length);
+		expect(entitiesAccountB).toHaveLength(snapshotsAccountB.length);
+		expect(entitiesCustomer).toHaveLength(2);
 
 		entitiesAccountA.forEach((entity, index) => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
-			expect(entity.registeredOn).toBeInstanceOf(Date);
+			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(typeof entity.registeredOn).toBe('number');
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
-		});
-
-		entitiesAccountB.forEach((entity, index) => {
-			expect(entity.streamId).toEqual(snapshotStreamAccountB.streamId);
-			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
-			expect(entity.aggregateId).toEqual(
-				envelopesAccountB[index].metadata.aggregateId,
-			);
-			expect(entity.registeredOn).toBeInstanceOf(Date);
-			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
 		});
 	});
 
-	it("should retrieve a single snapshot from a specified stream", async () => {
+	it('should retrieve a single snapshot from a specified stream', async () => {
 		const resolvedSnapshot = await snapshotStore.getSnapshot(
 			snapshotStreamAccountA,
 			envelopesAccountA[1].metadata.version,
 		);
 
-		expect(resolvedSnapshot).toEqual(snapshots[1]);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[1]);
 	});
 
-	it("should retrieve snapshots by stream", async () => {
+	it('should retrieve snapshots by stream', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA)) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots);
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA);
 	});
 
-	it("should filter snapshots by stream and version", async () => {
+	it('should filter snapshots by stream and version', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{
-				fromVersion: 30,
-			},
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			fromVersion: 30,
+		})) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(2));
 	});
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {
 		const stream = SnapshotStream.for(Account, AccountId.generate());
-		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(
-			new SnapshotNotFoundException(stream.streamId, 20),
-		);
+		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(new SnapshotNotFoundException(stream.streamId, 20));
 	});
 
-	it("should retrieve snapshots backwards", async () => {
+	it('should retrieve snapshots backwards', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{
-				direction: StreamReadingDirection.BACKWARD,
-			},
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice().reverse());
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice().reverse());
 	});
 
-	it("should retrieve snapshots backwards from a certain version", async () => {
+	it('should retrieve snapshots backwards from a certain version', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{
-				fromVersion: envelopesAccountA[1].metadata.version,
-				direction: StreamReadingDirection.BACKWARD,
-			},
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			fromVersion: envelopesAccountA[1].metadata.version,
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
 		expect(resolvedSnapshots).toEqual(
-			snapshots
-				.filter(
-					(_, index) =>
-						(index + 1) * 10 >= envelopesAccountA[1].metadata.version,
-				)
-				.reverse(),
+			snapshotsAccountA.filter((_, index) => (index + 1) * 10 >= envelopesAccountA[2].metadata.version).reverse(),
 		);
 	});
 
-	it("should limit the returned snapshots", async () => {
+	it('should limit the returned snapshots', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{ limit: 2 },
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
 	});
 
-	it("should batch the returned snapshots", async () => {
+	it('should batch the returned snapshots', async () => {
 		const resolvedSnapshots: ISnapshot<Account>[] = [];
-		for await (const snapshots of snapshotStore.getSnapshots(
-			snapshotStreamAccountA,
-			{ limit: 2 },
-		)) {
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
 			expect(snapshots.length).toBe(2);
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshots.slice(0, 2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
 	});
 
-	it("should retrieve the last snapshot", async () => {
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
-			snapshotStreamAccountA,
-		);
+	it('should retrieve the last snapshot', async () => {
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(snapshotStreamAccountA);
 
-		expect(resolvedSnapshot).toEqual(snapshots[snapshots.length - 1]);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
 	});
 
-	it("should return undefined if there is no last snapshot", async () => {
+	it('should return undefined if there is no last snapshot', async () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(
-			SnapshotStream.for(Foo, Id.generate()),
-		);
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
-	it("should retrieve snapshot-envelopes", async () => {
+	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getEnvelopes(
-			snapshotStreamAccountA,
-		)) {
+		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -279,39 +252,57 @@ describe(MongoDBSnapshotStore, () => {
 
 		resolvedEnvelopes.forEach((envelope, index) => {
 			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
-			expect(envelope.metadata.aggregateId).toEqual(
-				envelopesAccountA[index].metadata.aggregateId,
-			);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
 			expect(envelope.metadata.registeredOn).toBeInstanceOf(Date);
-			expect(envelope.metadata.version).toEqual(
-				envelopesAccountA[index].metadata.version,
-			);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
 
-	it("should retrieve a single snapshot-envelope", async () => {
+	it('should retrieve a single snapshot-envelope', async () => {
 		const { metadata, payload } = await snapshotStore.getEnvelope(
 			snapshotStreamAccountA,
 			envelopesAccountA[3].metadata.version,
 		);
 
 		expect(payload).toEqual(envelopesAccountA[3].payload);
-		expect(metadata.aggregateId).toEqual(
-			envelopesAccountA[3].metadata.aggregateId,
-		);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it("should retrieve the last snapshot-envelope", async () => {
+	it('should retrieve the last snapshot-envelope', async () => {
 		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = await snapshotStore.getLastEnvelope(
-			snapshotStreamAccountA,
-		);
+		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
 
 		expect(payload).toEqual(lastEnvelope.payload);
 		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);
 		expect(metadata.registeredOn).toBeInstanceOf(Date);
 		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
+	});
+
+	it('should retrieve the last snapshot-envelopes', async () => {
+		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+			resolvedEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedEnvelopes).toHaveLength(2);
+
+		const [envelopeAccountB, envelopeAccountA] = [
+			envelopesAccountB[envelopesAccountB.length - 1],
+			envelopesAccountA[envelopesAccountA.length - 1],
+		];
+
+		resolvedEnvelopes = resolvedEnvelopes.sort((a, b) => (a.metadata.version > b.metadata.version ? 1 : -1));
+
+		expect(resolvedEnvelopes[0].payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedEnvelopes[0].metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedEnvelopes[0].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[0].metadata.version).toEqual(envelopeAccountB.metadata.version);
+
+		expect(resolvedEnvelopes[1].payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
 	});
 });

--- a/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
@@ -144,7 +144,7 @@ describe(MongoDBSnapshotStore, () => {
 			expect(entity.streamId).toEqual(snapshotStreamAccountA.streamId);
 			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
 			expect(entity.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
-			expect(typeof entity.registeredOn).toBe('number');
+			expect(entity.registeredOn).toBeInstanceOf(Date);
 			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
 		});
 	});
@@ -175,7 +175,7 @@ describe(MongoDBSnapshotStore, () => {
 			resolvedSnapshots.push(...snapshots);
 		}
 
-		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(2));
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(3));
 	});
 
 	it("should throw when a snapshot isn't found in a specified stream", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
 		"example/**/*"
 	],
 	"exclude": [
-		"node_modules",
-		"**/*.spec.ts"
+		"node_modules"
 	]
 }


### PR DESCRIPTION
- :recycle: replace localhost with 127.0.0.1
- :sparkles: add a getter on a snapshot-stream for retrieving the aggregate name
- :memo: describe the purpose of the snapshot-handler
- :sparkles: make the snapshot handler store a snapshot at aggregate version 1
- :white_check_mark: test if a snapshot store returns all latest events for every aggregate stream
- :rotating_light: fix lint issues
- :sparkles: define what the getLatestSnapshots method should look like
- :sparkles: implement the getLatestSnapshots method on the mongodb snapshot-store
- :sparkles: add snapshot metadata helper
- :goal_net: add an exception for when snapshot metadata is not provided
- :wrench: also format and lint the example
- :heavy_plus_sign: add faker as a dev dependency
- :sparkles: allow to fetch all latest snapshots
- :recycle: fix query handler exception message
- :recycle: make the snapshot handler loadMany return envelopes
- :sparkles: add an implementation to test the snapshot-handler loadMany method
- :recycle: refactor the in-memory and mongodb snapshot stores
- :white_check_mark: test the aggregate load-many method
