### PR TITLE
update rome config and example

### DIFF
--- a/example/src/app.module.ts
+++ b/example/src/app.module.ts
@@ -16,8 +16,21 @@ import { AccountController } from './application/account.controller';
     EventSourcingModule.forRootAsync({
       useFactory: () => ({
 		events: [...Events],
-		eventStore: { client: 'in-memory' },
-		snapshotStore: { client: 'in-memory' },
+		eventStore: { client: 'dynamodb',
+		options: {
+			region: 'us-east-1',
+			endpoint: 'http://127.0.0.1:8000',
+			credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
+		} 
+	},
+		snapshotStore: { 
+			client: 'dynamodb',
+			options: {
+				region: 'us-east-1',
+				endpoint: 'http://127.0.0.1:8000',
+				credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
+			}
+		},
 	  }),
     }),
   ],

--- a/lib/integration/event-store/mongodb.event-store.ts
+++ b/lib/integration/event-store/mongodb.event-store.ts
@@ -21,6 +21,12 @@ export class MongoDBEventStore extends EventStore {
 
 	async setup(pool?: IEventPool): Promise<EventCollection> {
 		const collection = EventCollection.get(pool);
+
+		const [existingCollection] = await this.database.listCollections({ name: collection }).toArray();
+		if (existingCollection) {
+			return collection;
+		}
+
 		const eventCollection = await this.database.createCollection<MongoEventEntity>(collection);
 		await eventCollection.createIndex({ streamId: 1, version: 1 }, { unique: true });
 		return collection;

--- a/lib/integration/snapshot-store/mongodb.snapshot-store.ts
+++ b/lib/integration/snapshot-store/mongodb.snapshot-store.ts
@@ -22,6 +22,11 @@ export class MongoDBSnapshotStore extends SnapshotStore {
 	async setup(pool?: ISnapshotPool): Promise<SnapshotCollection> {
 		const collection = SnapshotCollection.get(pool);
 
+		const [existingCollection] = await this.database.listCollections({ name: collection }).toArray();
+		if (existingCollection) {
+			return collection;
+		}
+
 		const snapshotCollection = await this.database.createCollection(collection);
 		await snapshotCollection.createIndex({ streamId: 1, version: 1 }, { unique: true });
 		await snapshotCollection.createIndex({ aggregateName: 1, latest: 1 }, { unique: false });

--- a/lib/models/aggregate-root.ts
+++ b/lib/models/aggregate-root.ts
@@ -26,7 +26,7 @@ export abstract class AggregateRoot {
 		}
 
 		const handler = this.getEventHandler(event);
-		handler && handler.call(this, event);
+		handler?.call(this, event);
 	}
 
 	private getEventHandler<T extends IEvent = IEvent>(event: T): Type<typeof AggregateRoot> | undefined {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"mongodb-memory-server": "8.10.0",
 		"reflect-metadata": "0.1.13",
 		"release-it": "15.5.0",
-		"rome": "0.10.1-next",
+		"rome": "10.0.1",
 		"rxjs": "7.5.7",
 		"typescript": "4.8.4"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   mongodb-memory-server: 8.10.0
   reflect-metadata: 0.1.13
   release-it: 15.5.0
-  rome: 0.10.1-next
+  rome: 10.0.1
   rxjs: 7.5.7
   typescript: 4.8.4
 
@@ -46,7 +46,7 @@ devDependencies:
   mongodb-memory-server: 8.10.0
   reflect-metadata: 0.1.13
   release-it: 15.5.0
-  rome: 0.10.1-next
+  rome: 10.0.1
   rxjs: 7.5.7
   typescript: 4.8.4
 
@@ -2363,68 +2363,50 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@rometools/cli-darwin-arm64/0.10.1-next:
-    resolution: {integrity: sha512-nyNijAs52mIE6oAJOXEGgnJfiBRP2tN+puQbi88o4ktmSXR43XnXs2fTme7xXRwzZ6uwoc9kVRAbHsgFZpYgMA==}
+  /@rometools/cli-darwin-arm64/10.0.1:
+    resolution: {integrity: sha512-MwQjk3uhZrCu6LgIwJHREAsVt/mUQTGv7p8iosfaF8lCIxMVjyS+akbF/QcBufyW5sFtHYNWUEe/uKPHK4E//A==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rometools/cli-darwin-x64/0.10.1-next:
-    resolution: {integrity: sha512-O+1tDZKITaf/WaF3r1PnANGhm8Ex6IwrHXAFNVHEdy496jHfBGIzZ9wf6g8o2INpUe+OM6v6knA9wwjbMPmzSw==}
+  /@rometools/cli-darwin-x64/10.0.1:
+    resolution: {integrity: sha512-n010Wc/z9L8wRkRnR5boMhdWgDVGrTG/i7zL8u/3+F5aSUgLCywf9F/b3ex74tCJJfcwBLlhaAqAVQX6U1bIkA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rometools/cli-linux-arm64/0.10.1-next:
-    resolution: {integrity: sha512-aZGSrTaPzcHarlrA8hAO2ZbpoF1yl5BwhX93U5eM92jEJg9/NPl0RuVmZaiOIVN6gUu7Xv2PDE9S0ZqPUugcAA==}
+  /@rometools/cli-linux-arm64/10.0.1:
+    resolution: {integrity: sha512-JljZsnud1KCfe36VNsVh/LrYdAzgbKbcsCTzeCjW9ROkMyNj8pmQ/gIUFxZ+PyhMFgowHIDGihoNf4m+pgpxkA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rometools/cli-linux-x64/0.10.1-next:
-    resolution: {integrity: sha512-fVN7HhUVSEANQL8qFJbteX/8wLIFc+1HtTRxwoGEbmSZfXbIPalFuvkQ3o0pke2+LdpU1URiLzMIx+5gBwPjeA==}
+  /@rometools/cli-linux-x64/10.0.1:
+    resolution: {integrity: sha512-jXIqd9iDyZUexk63CRfAXDA4zNDUHpErUmCejjGab3dhDt1KA40fDqKb+kxZpAhY3tQoWNSNQyo750zX5NawLw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rometools/cli-win32-arm64/0.10.1-next:
-    resolution: {integrity: sha512-UMkSgQMslkTQ/QvwTdOsmQWlTc2RgiA4fsHv9thcDHdrV13+kUCsYQV5EA27ROVCFFdyxAG3OrZiRPbd92mHHA==}
+  /@rometools/cli-win32-arm64/10.0.1:
+    resolution: {integrity: sha512-G/toRrKPhhi7SMYMyROq/E2c8/4xRX/67vFhVihuMvDDzhanIb99hEt5MMbM4HbYK1nnZBPyLN6LxVsxm9M9hA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rometools/cli-win32-x64/0.10.1-next:
-    resolution: {integrity: sha512-1ZCdAZKtB/bzFDJtbSECfCE3f+d00n8+/8AShOZ4+gKTtJZMOZ56XWD+9MvLq16DUogyGKwR0IzVgIUzvOQGwQ==}
+  /@rometools/cli-win32-x64/10.0.1:
+    resolution: {integrity: sha512-y299+VGoBufZntZj0Xz7w9DODU+6E5giXStfBDoa0fspXGNkYyYfD+HC6j9gUv4zpMZJ607XVvVHjpfwM/3ftA==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/wasm-bundler/0.10.1-next:
-    resolution: {integrity: sha512-yREKu7ZgmKfCOvxYvX7EmJu65mNT+BioaJf3Vep/mCI+/S6WJotMomNogeMzfrWQ06VhEVkqebV4x8W1hFLMjg==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/wasm-nodejs/0.10.1-next:
-    resolution: {integrity: sha512-4aiPUhsumpzj497ipSAqQhJTT12hVS2IJaVe4hztGxqZgLlrm1hbWWal/XzUMYYh30iGAaqZIfR8vuA4E8WCoQ==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rometools/wasm-web/0.10.1-next:
-    resolution: {integrity: sha512-FjPkty4Rab2fEciL4tonpDwHpOyHVgAdxhz3BhSnDlEMCW1VnFCpk45v/2srDrBCY+W23++zQyBbDoZKbjIbJA==}
     requiresBuild: true
     dev: true
     optional: true
@@ -6017,21 +5999,18 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rome/0.10.1-next:
-    resolution: {integrity: sha512-WB+zT+NGE6pqSmNgemlAwreE2BwWLi6rQ3g8L1IlBOvBI8QB0iRMgYRmdVxBMjQ2X6CDnCuDnbKOE3uqC50qvw==}
+  /rome/10.0.1:
+    resolution: {integrity: sha512-RfaDa+cSustBsjX6bj3fWqEhoNxXrK1uNgKHpkCHAqp20QMJXnCRtbokhirNMe0utyGI9GTO/sDoK7hJP7O8Bw==}
     engines: {node: '>=14.*'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@rometools/cli-darwin-arm64': 0.10.1-next
-      '@rometools/cli-darwin-x64': 0.10.1-next
-      '@rometools/cli-linux-arm64': 0.10.1-next
-      '@rometools/cli-linux-x64': 0.10.1-next
-      '@rometools/cli-win32-arm64': 0.10.1-next
-      '@rometools/cli-win32-x64': 0.10.1-next
-      '@rometools/wasm-bundler': 0.10.1-next
-      '@rometools/wasm-nodejs': 0.10.1-next
-      '@rometools/wasm-web': 0.10.1-next
+      '@rometools/cli-darwin-arm64': 10.0.1
+      '@rometools/cli-darwin-x64': 10.0.1
+      '@rometools/cli-linux-arm64': 10.0.1
+      '@rometools/cli-linux-x64': 10.0.1
+      '@rometools/cli-win32-arm64': 10.0.1
+      '@rometools/cli-win32-x64': 10.0.1
     dev: true
 
   /run-async/2.4.1:

--- a/rome.json
+++ b/rome.json
@@ -3,9 +3,12 @@
 		"enabled": true,
 		"rules": {
 			"recommended": true,
-			"nursery": {
-				"recommended": true,
+			"correctness": {
+				"useSingleCaseStatement": "off",
 				"noUnusedVariables": "off"
+			},
+			"style": {
+				"useShorthandArrayType": "off"
 			}
 		}
 	},


### PR DESCRIPTION
- :hammer: update rome config
- :sparkles: if the dynamodb collections exist, skip the setup
- :sparkles: update example

# This PR
- fixes the Rome config to the new format
- uses dynamodb in the example
- doesn't try to create event and snapshot collections if they already exist

