### PR TITLE
try using Id without the uuid constrant

### DIFF
--- a/lib/models/id.ts
+++ b/lib/models/id.ts
@@ -8,10 +8,6 @@ interface Props {
 
 export class Id extends ValueObject<Props> {
 	protected constructor(id: string = randomUUID()) {
-		const format = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
-		if (!format.test(id)) {
-			throw InvalidIdError.becauseInvalid(id);
-		}
 		super({ value: id });
 	}
 

--- a/tests/unit/models/id.spec.ts
+++ b/tests/unit/models/id.spec.ts
@@ -19,11 +19,4 @@ describe(Aggregate, () => {
 		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.becauseEmpty());
 	});
 
-	it('should throw when creating an Id from an invalid uuid', () => {
-		const generatedAccountId = AccountId.generate();
-		expect(generatedAccountId.value).toBeDefined();
-
-		const uuid = '123-abc';
-		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.because(`${uuid} is not a valid v4 uuid`));
-	});
 });


### PR DESCRIPTION
this relates to issue https://github.com/ocoda/event-sourcing/issues/107

where we need to have an aggregate model have an id provided by an external system, in particular, their publicKeys for devices that our service needs to manage.

I haven't been able to test if this will just work, as I'm currently in poor reception and cant call package manager to install all of the dependencies. I can try test later tonight though when in better internet