### PR TITLE
allow generic ids

### DIFF
--- a/example/src/domain/models/account.aggregate.ts
+++ b/example/src/domain/models/account.aggregate.ts
@@ -1,4 +1,4 @@
-import { Aggregate, AggregateRoot, Id } from '@ocoda/event-sourcing';
+import { Aggregate, AggregateRoot, UUID } from '@ocoda/event-sourcing';
 import {
 	AccountClosedEvent,
 	AccountCreditedEvent,
@@ -8,8 +8,8 @@ import {
 	AccountOwnerRemovedEvent,
 } from '../events';
 
-export class AccountId extends Id {}
-export class AccountOwnerId extends Id {}
+export class AccountId extends UUID {}
+export class AccountOwnerId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 export class Account extends AggregateRoot {

--- a/lib/models/event-envelope.ts
+++ b/lib/models/event-envelope.ts
@@ -1,5 +1,5 @@
 import { EventEnvelopeMetadata, IEvent, IEventPayload } from '../interfaces';
-import { Id } from './id';
+import { UUID } from './uuid';
 
 export class EventEnvelope<E extends IEvent = IEvent> {
 	private constructor(
@@ -11,10 +11,12 @@ export class EventEnvelope<E extends IEvent = IEvent> {
 	static create<E extends IEvent = IEvent>(
 		event: string,
 		payload: IEventPayload<E>,
-		metadata: Omit<EventEnvelopeMetadata, 'eventId' | 'occurredOn'>,
+		metadata: Omit<EventEnvelopeMetadata, 'eventId' | 'occurredOn'> & {
+			eventId?: string;
+		},
 	): EventEnvelope<E> {
 		return new EventEnvelope<E>(event, payload, {
-			eventId: Id.generate().value,
+			eventId: metadata.eventId || UUID.generate().value,
 			occurredOn: new Date(),
 			...metadata,
 		});

--- a/lib/models/id.ts
+++ b/lib/models/id.ts
@@ -7,16 +7,8 @@ interface Props {
 }
 
 export class Id extends ValueObject<Props> {
-	protected constructor(id: string = randomUUID()) {
-		const format = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
-		if (!format.test(id)) {
-			throw InvalidIdError.becauseInvalid(id);
-		}
+	protected constructor(id: string) {
 		super({ value: id });
-	}
-
-	public static generate(): Id {
-		return new Id();
 	}
 
 	public static from(id: string): Id {

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -3,6 +3,7 @@ export * from './event-collection';
 export * from './event-envelope';
 export * from './event-stream';
 export * from './id';
+export * from './uuid';
 export * from './snapshot-collection';
 export * from './snapshot-envelope';
 export * from './snapshot-stream';

--- a/lib/models/snapshot-envelope.ts
+++ b/lib/models/snapshot-envelope.ts
@@ -1,16 +1,18 @@
 import { ISnapshot, SnapshotEnvelopeMetadata } from '../interfaces';
 import { AggregateRoot } from './aggregate-root';
-import { Id } from './id';
+import { UUID } from './uuid';
 
 export class SnapshotEnvelope<A extends AggregateRoot = AggregateRoot> {
 	private constructor(readonly payload: ISnapshot<A>, readonly metadata: SnapshotEnvelopeMetadata) {}
 
 	static create<A extends AggregateRoot>(
 		payload: ISnapshot<A>,
-		metadata: Omit<SnapshotEnvelopeMetadata, 'snapshotId' | 'registeredOn'>,
+		metadata: Omit<SnapshotEnvelopeMetadata, 'eventId' | 'registeredOn'> & {
+			snapshotId?: string;
+		},
 	): SnapshotEnvelope<A> {
 		return new SnapshotEnvelope(payload, {
-			snapshotId: Id.generate().value,
+			snapshotId: metadata.snapshotId || UUID.generate().value,
 			registeredOn: new Date(),
 			...metadata,
 		});

--- a/lib/models/snapshot-envelope.ts
+++ b/lib/models/snapshot-envelope.ts
@@ -7,7 +7,7 @@ export class SnapshotEnvelope<A extends AggregateRoot = AggregateRoot> {
 
 	static create<A extends AggregateRoot>(
 		payload: ISnapshot<A>,
-		metadata: Omit<SnapshotEnvelopeMetadata, 'eventId' | 'registeredOn'> & {
+		metadata: Omit<SnapshotEnvelopeMetadata, 'snapshotId' | 'registeredOn'> & {
 			snapshotId?: string;
 		},
 	): SnapshotEnvelope<A> {

--- a/lib/models/uuid.ts
+++ b/lib/models/uuid.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+import { InvalidIdError } from '../exceptions';
+import { Id } from './id';
+
+export class UUID extends Id {
+	protected constructor(id: string = randomUUID()) {
+		const format = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+		if (!format.test(id)) {
+			throw InvalidIdError.becauseInvalid(id);
+		}
+		super(id);
+	}
+
+	public static generate(): UUID {
+		return new UUID();
+	}
+
+	public static from(id: string): UUID {
+		if (!id) {
+			throw InvalidIdError.becauseEmpty();
+		}
+		return new UUID(id);
+	}
+
+	get value(): string {
+		return this.props.value;
+	}
+}

--- a/tests/e2e/src/domain/models/account.aggregate.ts
+++ b/tests/e2e/src/domain/models/account.aggregate.ts
@@ -1,4 +1,4 @@
-import { Aggregate, AggregateRoot, Id } from '@ocoda/event-sourcing';
+import { Aggregate, AggregateRoot, UUID } from '@ocoda/event-sourcing';
 import {
 	AccountClosedEvent,
 	AccountCreditedEvent,
@@ -8,8 +8,8 @@ import {
 	AccountOwnerRemovedEvent,
 } from '../events';
 
-export class AccountId extends Id {}
-export class AccountOwnerId extends Id {}
+export class AccountId extends UUID {}
+export class AccountOwnerId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 export class Account extends AggregateRoot {

--- a/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/dynamodb.event-store.spec.ts
@@ -9,14 +9,14 @@ import {
 	EventMap,
 	EventNotFoundException,
 	EventStream,
-	Id,
 	IEvent,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import { DefaultEventSerializer } from '../../../../lib/helpers';
 import { DynamoDBEventStore } from '../../../../lib/integration/event-store/dynamodb.event-store';
 
-class AccountId extends Id {}
+class AccountId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {

--- a/tests/unit/integration/event-store/in-memory.event-store.spec.ts
+++ b/tests/unit/integration/event-store/in-memory.event-store.spec.ts
@@ -6,14 +6,14 @@ import {
 	EventMap,
 	EventNotFoundException,
 	EventStream,
-	Id,
 	IEvent,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import { DefaultEventSerializer } from '../../../../lib/helpers';
 import { InMemoryEventEntity, InMemoryEventStore } from '../../../../lib/integration/event-store';
 
-class AccountId extends Id {}
+class AccountId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {

--- a/tests/unit/integration/event-store/mongodb.event-store.spec.ts
+++ b/tests/unit/integration/event-store/mongodb.event-store.spec.ts
@@ -8,14 +8,14 @@ import {
 	EventMap,
 	EventNotFoundException,
 	EventStream,
-	Id,
 	IEvent,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import { DefaultEventSerializer } from '../../../../lib/helpers';
 import { MongoDBEventStore, MongoEventEntity } from '../../../../lib/integration/event-store/mongodb.event-store';
 
-class AccountId extends Id {}
+class AccountId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {

--- a/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/dynamodb.snapshot-store.spec.ts
@@ -4,18 +4,18 @@ import { randomInt } from 'crypto';
 import {
 	Aggregate,
 	AggregateRoot,
-	Id,
 	ISnapshot,
 	SnapshotCollection,
 	SnapshotEnvelope,
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import { DynamoDBSnapshotStore } from '../../../../lib/integration/snapshot-store/dynamodb.snapshot-store';
 
-class AccountId extends Id {}
-class CustomerId extends Id {}
+class AccountId extends UUID {}
+class CustomerId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
@@ -258,7 +258,7 @@ describe(DynamoDBSnapshotStore, () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, UUID.generate()));
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});
@@ -331,7 +331,7 @@ describe(DynamoDBSnapshotStore, () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		class FooId extends Id {}
+		class FooId extends UUID {}
 
 		const fooIds = Array.from({ length: 20 })
 			.map(() => FooId.generate())

--- a/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -1,17 +1,17 @@
 import {
 	Aggregate,
 	AggregateRoot,
-	Id,
 	ISnapshot,
 	SnapshotEnvelope,
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import { InMemorySnapshotStore } from '../../../../lib/integration/snapshot-store';
 
-class AccountId extends Id {}
-class CustomerId extends Id {}
+class AccountId extends UUID {}
+class CustomerId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
@@ -217,7 +217,7 @@ describe(InMemorySnapshotStore, () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
+		const resolvedSnapshot = snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, UUID.generate()));
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});

--- a/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
+++ b/tests/unit/integration/snapshot-store/mongodb.snapshot-store.spec.ts
@@ -2,21 +2,21 @@ import { MongoClient } from 'mongodb';
 import {
 	Aggregate,
 	AggregateRoot,
-	Id,
 	ISnapshot,
 	SnapshotCollection,
 	SnapshotEnvelope,
 	SnapshotNotFoundException,
 	SnapshotStream,
 	StreamReadingDirection,
+	UUID,
 } from '../../../../lib';
 import {
 	MongoDBSnapshotStore,
 	MongoSnapshotEntity,
 } from '../../../../lib/integration/snapshot-store/mongodb.snapshot-store';
 
-class AccountId extends Id {}
-class CustomerId extends Id {}
+class AccountId extends UUID {}
+class CustomerId extends UUID {}
 
 @Aggregate({ streamName: 'account' })
 class Account extends AggregateRoot {
@@ -240,7 +240,7 @@ describe(MongoDBSnapshotStore, () => {
 		@Aggregate({ streamName: 'foo' })
 		class Foo extends AggregateRoot {}
 
-		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, Id.generate()));
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, UUID.generate()));
 
 		expect(resolvedSnapshot).toBeUndefined();
 	});

--- a/tests/unit/models/event-envelope.spec.ts
+++ b/tests/unit/models/event-envelope.spec.ts
@@ -1,7 +1,7 @@
-import { EventEnvelope, Id, IEvent } from '../../../lib';
+import { EventEnvelope, IEvent, UUID } from '../../../lib';
 
 describe(EventEnvelope, () => {
-	class FooId extends Id {}
+	class FooId extends UUID {}
 	class FooCreatedEvent implements IEvent {
 		constructor(public readonly bar: string) {}
 	}

--- a/tests/unit/models/event-stream.spec.ts
+++ b/tests/unit/models/event-stream.spec.ts
@@ -1,9 +1,9 @@
-import { Aggregate, AggregateRoot, EventStream, Id, MissingAggregateMetadataException } from '../../../lib';
+import { Aggregate, AggregateRoot, EventStream, MissingAggregateMetadataException, UUID } from '../../../lib';
 
 describe(EventStream, () => {
 	@Aggregate({ streamName: 'account' })
 	class Account extends AggregateRoot {}
-	class AccountId extends Id {}
+	class AccountId extends UUID {}
 
 	it('should create an EventStream from an Aggregate class', () => {
 		const accountId = AccountId.generate();
@@ -23,7 +23,7 @@ describe(EventStream, () => {
 	});
 
 	it('should throw when creating an event-stream for an undecorated aggregate', () => {
-		class FooId extends Id {}
+		class FooId extends UUID {}
 		class Foo extends AggregateRoot {}
 
 		expect(() => EventStream.for(Foo, FooId.generate())).toThrow(new MissingAggregateMetadataException(Foo));

--- a/tests/unit/models/id.spec.ts
+++ b/tests/unit/models/id.spec.ts
@@ -1,7 +1,7 @@
-import { Aggregate, Id, InvalidIdError } from '../../../lib';
+import { Aggregate, InvalidIdError, UUID } from '../../../lib';
 
 describe(Aggregate, () => {
-	class AccountId extends Id {}
+	class AccountId extends UUID {}
 
 	it('should generate an AccountId', () => {
 		const generatedAccountId = AccountId.generate();

--- a/tests/unit/models/id.spec.ts
+++ b/tests/unit/models/id.spec.ts
@@ -1,29 +1,25 @@
-import { Aggregate, InvalidIdError, UUID } from '../../../lib';
+import { Id, InvalidIdError } from '../../../lib';
 
-describe(Aggregate, () => {
-	class AccountId extends UUID {}
+describe(Id, () => {
+	class DeviceId extends Id {
+		public static generate(): DeviceId {
+			return new DeviceId('123-abc');
+		}
+	}
 
-	it('should generate an AccountId', () => {
-		const generatedAccountId = AccountId.generate();
-		expect(generatedAccountId.value).toBeDefined();
+	it('should generate a DeviceId', () => {
+		const generatedDeviceId = DeviceId.generate();
+		expect(generatedDeviceId.value).toBeDefined();
 	});
 
-	it('should create an AccountId from an existing uuid', () => {
-		const uuid = 'b6bca415-b7a6-499c-9f39-bf8fbf980a82';
-		const createdAccountId = AccountId.from(uuid);
-		expect(createdAccountId.value).toBe(uuid);
+	it('should create a DeviceId from an existing id', () => {
+		const id = '123-abc';
+		const createdDeviceId = DeviceId.from(id);
+		expect(createdDeviceId.value).toBe(id);
 	});
 
 	it('should throw when trying to create an id from an undefined variable', () => {
-		let uuid: string;
-		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.becauseEmpty());
-	});
-
-	it('should throw when creating an Id from an invalid uuid', () => {
-		const generatedAccountId = AccountId.generate();
-		expect(generatedAccountId.value).toBeDefined();
-
-		const uuid = '123-abc';
-		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.because(`${uuid} is not a valid v4 uuid`));
+		let id: string;
+		expect(() => DeviceId.from(id)).toThrow(InvalidIdError.becauseEmpty());
 	});
 });

--- a/tests/unit/models/snapshot-envelope.spec.ts
+++ b/tests/unit/models/snapshot-envelope.spec.ts
@@ -1,7 +1,7 @@
-import { AggregateRoot, Id, ISnapshot, SnapshotEnvelope } from '../../../lib';
+import { AggregateRoot, ISnapshot, SnapshotEnvelope, UUID } from '../../../lib';
 
 describe(SnapshotEnvelope, () => {
-	class AccountId extends Id {}
+	class AccountId extends UUID {}
 	class Account extends AggregateRoot {
 		constructor(public id: AccountId, public balance: number, public openedOn: Date, public closedOn?: Date) {
 			super();
@@ -17,7 +17,10 @@ describe(SnapshotEnvelope, () => {
 			closedOn: undefined,
 		};
 
-		const envelope = SnapshotEnvelope.create(accountSnapshot, { aggregateId: accountId.value, version: 1 });
+		const envelope = SnapshotEnvelope.create(accountSnapshot, {
+			aggregateId: accountId.value,
+			version: 1,
+		});
 
 		expect(envelope.payload).toEqual(accountSnapshot);
 		expect(envelope.metadata.aggregateId).toEqual(accountId.value);

--- a/tests/unit/models/snapshot-stream.spec.ts
+++ b/tests/unit/models/snapshot-stream.spec.ts
@@ -1,9 +1,9 @@
-import { Aggregate, AggregateRoot, Id, MissingAggregateMetadataException, SnapshotStream } from '../../../lib';
+import { Aggregate, AggregateRoot, MissingAggregateMetadataException, SnapshotStream, UUID } from '../../../lib';
 
 describe(SnapshotStream, () => {
 	@Aggregate({ streamName: 'account' })
 	class Account extends AggregateRoot {}
-	class AccountId extends Id {}
+	class AccountId extends UUID {}
 
 	it('should create a SnapshotStream from an Aggregate class', () => {
 		const accountId = AccountId.generate();
@@ -23,7 +23,7 @@ describe(SnapshotStream, () => {
 	});
 
 	it('should throw when creating a snapshot-stream for an undecorated aggregate', () => {
-		class FooId extends Id {}
+		class FooId extends UUID {}
 		class Foo extends AggregateRoot {}
 
 		expect(() => SnapshotStream.for(Foo, FooId.generate())).toThrow(new MissingAggregateMetadataException(Foo));

--- a/tests/unit/models/uuid.spec.ts
+++ b/tests/unit/models/uuid.spec.ts
@@ -1,0 +1,29 @@
+import { InvalidIdError, UUID } from '../../../lib';
+
+describe(UUID, () => {
+	class AccountId extends UUID {}
+
+	it('should generate an AccountId', () => {
+		const generatedAccountId = AccountId.generate();
+		expect(generatedAccountId.value).toBeDefined();
+	});
+
+	it('should create an AccountId from an existing uuid', () => {
+		const uuid = 'b6bca415-b7a6-499c-9f39-bf8fbf980a82';
+		const createdAccountId = AccountId.from(uuid);
+		expect(createdAccountId.value).toBe(uuid);
+	});
+
+	it('should throw when trying to create an id from an undefined variable', () => {
+		let uuid: string;
+		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.becauseEmpty());
+	});
+
+	it('should throw when creating an Id from an invalid uuid', () => {
+		const generatedAccountId = AccountId.generate();
+		expect(generatedAccountId.value).toBeDefined();
+
+		const uuid = '123-abc';
+		expect(() => AccountId.from(uuid)).toThrow(InvalidIdError.because(`${uuid} is not a valid v4 uuid`));
+	});
+});

--- a/tests/unit/snapshot-handler.spec.ts
+++ b/tests/unit/snapshot-handler.spec.ts
@@ -1,7 +1,6 @@
 import {
 	Aggregate,
 	AggregateRoot,
-	Id,
 	ISnapshot,
 	ISnapshotPool,
 	Snapshot,
@@ -9,6 +8,7 @@ import {
 	SnapshotHandler,
 	SnapshotStore,
 	SnapshotStream,
+	UUID,
 } from '@ocoda/event-sourcing';
 
 describe(SnapshotHandler, () => {
@@ -20,7 +20,7 @@ describe(SnapshotHandler, () => {
 		public openedOn: Date;
 	}
 
-	class AccountId extends Id {}
+	class AccountId extends UUID {}
 
 	const snapshotInterval = 5;
 


### PR DESCRIPTION
- :recycle: don't make the Id class enforce a UUID format
- :sparkles: create a UUID VO for internal purposes
- :sparkles: allow to override the Id set in the event- and snapshot-envelopes
- ✅  update the tests to use the new UUID class
- :recycle: update the examples

This PR allows users to create their own Id value object class and pass these Id's to the event- and snapshot-envelopes.
