### PR TITLE
🔧 exclude vscode and github folders from release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,18 @@
 # source
+example
 index.ts
 lib
 tests
-example
 
 # misc
 .circleci
+.github
 .release-it.json
+.vscode
+biome.json
 docker-compose.yml
 jest.config.js
 pnpm-lock.yaml
 renovate.json
-biome.json
 tsconfig.build.json
 tsconfig.json


### PR DESCRIPTION
# Description

Excludes the `.github` and `.vscode` folders from the npm published build.
