### PR TITLE
[287] Add a MariaDB integration

### DIFF
--- a/.github/workflows/ci-libraries.yml
+++ b/.github/workflows/ci-libraries.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        database: [mongodb, dynamodb, postgres]
+        database: [mongodb, dynamodb, postgres, mariadb]
 
     name: Test ${{ matrix.database }} lib [Node.js ${{ matrix.node-version }}]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,3 +32,17 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/postgresql/data
+
+  mariadb:
+    container_name: es-mariadb
+    image: mariadb:latest
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+      MYSQL_DATABASE: mariadb
+      MYSQL_USER: mariadb
+      MYSQL_PASSWORD: mariadb
+    volumes:
+      - type: tmpfs
+        target: /var/lib/mysql

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -199,11 +199,10 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 	async *getLastEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		let entities: InMemorySnapshotEntity<any>[] = [];
 
-		const collection = SnapshotCollection.get(pool);
+		const collection = SnapshotCollection.get(filter?.pool);
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;

--- a/packages/core/lib/interfaces/aggregate/snapshot-handler.ts
+++ b/packages/core/lib/interfaces/aggregate/snapshot-handler.ts
@@ -51,7 +51,7 @@ export abstract class SnapshotHandler<A extends AggregateRoot = AggregateRoot> i
 
 		return aggregate;
 	}
-	async *loadMany(filter?: { fromId?: Id; limit?: number }): AsyncGenerator<SnapshotEnvelope<A>[]> {
+	async *loadMany(filter?: { fromId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		const id = filter?.fromId?.value;
 		for await (const envelopes of this.snapshotStore.getLastEnvelopes<A>(this.streamName, {
 			...filter,

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -30,7 +30,7 @@ export interface SnapshotFilter {
 	batch?: number;
 }
 
-export interface LatestSnapshotFilter extends Pick<SnapshotFilter, 'batch' | 'limit'> {
+export interface LatestSnapshotFilter extends Pick<SnapshotFilter, 'batch' | 'limit' | 'pool'> {
 	fromId?: string;
 }
 
@@ -77,6 +77,5 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	abstract getLastEnvelopes?<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;
 }

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -3,7 +3,7 @@
 	"extends": ["//"],
 	"tasks": {
 		"build": {
-			"outputs": ["dist/core/**"]
+			"outputs": ["dist/**"]
 		},
 		"test": {},
 		"test:ci": {},

--- a/packages/integration/dynamodb/lib/dynamodb-snapshot-store.ts
+++ b/packages/integration/dynamodb/lib/dynamodb-snapshot-store.ts
@@ -316,9 +316,8 @@ export class DynamoDBSnapshotStore extends SnapshotStore<DynamoDBSnapshotStoreCo
 	async *getLastEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
-		const collection = SnapshotCollection.get(pool);
+		const collection = SnapshotCollection.get(filter?.pool);
 
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;

--- a/packages/integration/dynamodb/turbo.json
+++ b/packages/integration/dynamodb/turbo.json
@@ -4,7 +4,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["@ocoda/event-sourcing#build"],
-			"outputs": ["dist/integration/dynamodb/**"]
+			"outputs": ["dist/**"]
 		},
 		"test": {},
 		"test:ci": {},

--- a/packages/integration/mariadb/biome.json
+++ b/packages/integration/mariadb/biome.json
@@ -1,0 +1,6 @@
+{
+	"extends": ["../../../biome.json"],
+	"files": {
+		"include": ["index.ts", "index.d.ts", "lib/**/*.ts", "tests/**/*.ts", "package.json"]
+	}
+}

--- a/packages/integration/mariadb/index.d.ts
+++ b/packages/integration/mariadb/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist';

--- a/packages/integration/mariadb/index.js
+++ b/packages/integration/mariadb/index.js
@@ -1,0 +1,17 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./dist"), exports);

--- a/packages/integration/mariadb/index.ts
+++ b/packages/integration/mariadb/index.ts
@@ -1,0 +1,1 @@
+export * from './dist';

--- a/packages/integration/mariadb/jest.config.js
+++ b/packages/integration/mariadb/jest.config.js
@@ -1,0 +1,32 @@
+module.exports = {
+	moduleFileExtensions: ['js', 'json', 'ts'],
+	rootDir: '.',
+	testRegex: '.*\\.spec\\.ts$',
+	transform: {
+		'^.+\\.(t|j)s$': [
+			'@swc/jest',
+			{
+				jsc: {
+					parser: {
+						syntax: 'typescript',
+						decorators: true,
+					},
+					transform: {
+						legacyDecorator: true,
+						decoratorMetadata: true,
+					},
+					target: 'es2016',
+					keepClassNames: true,
+				},
+				minify: false,
+			},
+		],
+	},
+	collectCoverageFrom: ['lib/**/*.(t|j)s'],
+	coverageDirectory: './coverage',
+	testEnvironment: 'node',
+	moduleNameMapper: {
+		'^@ocoda/event-sourcing(|/.*)$': '<rootDir>/../../core/lib/$1',
+		'^@ocoda/event-sourcing-mariadb(|/.*)$': '<rootDir>/lib/$1',
+	},
+};

--- a/packages/integration/mariadb/lib/index.ts
+++ b/packages/integration/mariadb/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
 export * from './mariadb-event-store';
+export * from './mariadb-snapshot-store';

--- a/packages/integration/mariadb/lib/index.ts
+++ b/packages/integration/mariadb/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './mariadb-event-store';

--- a/packages/integration/mariadb/lib/interfaces/index.ts
+++ b/packages/integration/mariadb/lib/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './mariadb-event-entity';
+export * from './mariadb-event-store-config';

--- a/packages/integration/mariadb/lib/interfaces/index.ts
+++ b/packages/integration/mariadb/lib/interfaces/index.ts
@@ -1,2 +1,4 @@
 export * from './mariadb-event-entity';
 export * from './mariadb-event-store-config';
+export * from './mariadb-snapshot-entity';
+export * from './mariadb-snapshot-store-config';

--- a/packages/integration/mariadb/lib/interfaces/mariadb-event-entity.ts
+++ b/packages/integration/mariadb/lib/interfaces/mariadb-event-entity.ts
@@ -1,0 +1,13 @@
+import { IEvent, IEventPayload } from '@ocoda/event-sourcing';
+
+export type MariaDBEventEntity = {
+	stream_id: string;
+	version: number;
+	event: string;
+	payload: IEventPayload<IEvent>;
+	event_id: string;
+	aggregate_id: string;
+	occurred_on: Date;
+	correlation_id: string | null;
+	causation_id: string | null;
+};

--- a/packages/integration/mariadb/lib/interfaces/mariadb-event-store-config.ts
+++ b/packages/integration/mariadb/lib/interfaces/mariadb-event-store-config.ts
@@ -1,0 +1,8 @@
+import { Type } from '@nestjs/common';
+import { EventStoreConfig } from '@ocoda/event-sourcing';
+import { PoolConfig } from 'mariadb';
+import { MariaDBEventStore } from '../mariadb-event-store';
+
+export interface MariaDBEventStoreConfig extends EventStoreConfig, PoolConfig {
+	driver: Type<MariaDBEventStore>;
+}

--- a/packages/integration/mariadb/lib/interfaces/mariadb-snapshot-entity.ts
+++ b/packages/integration/mariadb/lib/interfaces/mariadb-snapshot-entity.ts
@@ -1,0 +1,12 @@
+import { AggregateRoot, ISnapshot } from '@ocoda/event-sourcing';
+
+export type MariaDBSnapshotEntity<A extends AggregateRoot> = {
+	stream_id: string;
+	version: number;
+	payload: ISnapshot<A>;
+	snapshot_id: string;
+	aggregate_id: string;
+	registered_on: Date;
+	aggregate_name: string;
+	latest?: string;
+};

--- a/packages/integration/mariadb/lib/interfaces/mariadb-snapshot-store-config.ts
+++ b/packages/integration/mariadb/lib/interfaces/mariadb-snapshot-store-config.ts
@@ -1,0 +1,8 @@
+import { Type } from '@nestjs/common';
+import { SnapshotStoreConfig } from '@ocoda/event-sourcing';
+import { PoolConfig } from 'mariadb';
+import { MariaDBSnapshotStore } from '../mariadb-snapshot-store';
+
+export interface MariaDBSnapshotStoreConfig extends SnapshotStoreConfig, PoolConfig {
+	driver: Type<MariaDBSnapshotStore>;
+}

--- a/packages/integration/mariadb/lib/mariadb-event-store.ts
+++ b/packages/integration/mariadb/lib/mariadb-event-store.ts
@@ -1,0 +1,227 @@
+import {
+	DEFAULT_BATCH_SIZE,
+	EventCollection,
+	EventEnvelope,
+	EventFilter,
+	EventNotFoundException,
+	EventStore,
+	EventStream,
+	IEvent,
+	IEventCollection,
+	IEventPool,
+	StreamReadingDirection,
+} from '@ocoda/event-sourcing';
+import { Pool, createPool } from 'mariadb';
+import { MariaDBEventEntity, MariaDBEventStoreConfig } from './interfaces';
+
+export class MariaDBEventStore extends EventStore<MariaDBEventStoreConfig> {
+	private pool: Pool;
+
+	async start(): Promise<IEventCollection> {
+		this.logger.log('Starting store');
+		const { pool, ...params } = this.options;
+
+		this.pool = createPool(params);
+
+		const collection = EventCollection.get(pool);
+
+		await this.pool.query(
+			`CREATE TABLE IF NOT EXISTS \`${collection}\` (
+                stream_id VARCHAR(255) NOT NULL,
+                version INT NOT NULL,
+                event VARCHAR(255) NOT NULL,
+                payload JSON NOT NULL,
+                event_id VARCHAR(255) NOT NULL,
+                aggregate_id VARCHAR(255) NOT NULL,
+                occurred_on TIMESTAMP NOT NULL,
+                correlation_id VARCHAR(255),
+                causation_id VARCHAR(255),
+                PRIMARY KEY (stream_id, version)
+            )`,
+		);
+
+		return collection;
+	}
+
+	async stop(): Promise<void> {
+		this.logger.log('Stopping store');
+		await this.pool.end();
+	}
+
+	async *getEvents({ streamId }: EventStream, filter?: EventFilter): AsyncGenerator<IEvent[]> {
+		const connection = this.pool.getConnection();
+		const collection = EventCollection.get(filter?.pool);
+
+		const fromVersion = filter?.fromVersion;
+		const direction = filter?.direction || StreamReadingDirection.FORWARD;
+		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const query = `
+            SELECT event, payload
+            FROM \`${collection}\`
+            WHERE stream_id = ?
+            ${fromVersion ? 'AND version >= ?' : ''}
+            ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
+            LIMIT ?
+        `;
+
+		const params = fromVersion ? [streamId, fromVersion, limit] : [streamId, limit];
+
+		const client = await connection;
+		const stream = client.queryStream(query, params);
+
+		try {
+			let batchedEvents: IEvent[] = [];
+			for await (const { event, payload } of stream as unknown as Pick<MariaDBEventEntity, 'event' | 'payload'>[]) {
+				batchedEvents.push(this.eventMap.deserializeEvent(event, payload));
+				if (batchedEvents.length === batch) {
+					yield batchedEvents;
+					batchedEvents = [];
+				}
+			}
+			if (batchedEvents.length > 0) {
+				yield batchedEvents;
+			}
+		} catch (e) {
+			stream.destroy();
+		} finally {
+			await client.release();
+		}
+	}
+
+	async getEvent({ streamId }: EventStream, version: number, pool?: IEventPool): Promise<IEvent> {
+		const collection = EventCollection.get(pool);
+
+		const entities = await this.pool.query<Pick<MariaDBEventEntity, 'event' | 'payload'>[]>(
+			`SELECT event, payload FROM \`${collection}\` WHERE stream_id = ? AND version = ?`,
+			[streamId, version],
+		);
+		const entity = entities[0];
+
+		if (!entity) {
+			throw new EventNotFoundException(streamId, version);
+		}
+
+		return this.eventMap.deserializeEvent(entity.event, entity.payload);
+	}
+
+	async appendEvents(
+		{ streamId, aggregateId }: EventStream,
+		aggregateVersion: number,
+		events: IEvent[],
+		pool?: IEventPool,
+	): Promise<EventEnvelope[]> {
+		const collection = EventCollection.get(pool);
+
+		let version = aggregateVersion - events.length + 1;
+
+		const envelopes: EventEnvelope[] = [];
+		for (const event of events) {
+			const name = this.eventMap.getName(event);
+			const payload = this.eventMap.serializeEvent(event);
+			const envelope = EventEnvelope.create(name, payload, { aggregateId, version: version++ });
+			envelopes.push(envelope);
+		}
+
+		await this.pool.batch(
+			`INSERT INTO \`${collection}\` VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			envelopes.map(({ event, payload, metadata }) => [
+				streamId,
+				metadata.version,
+				event,
+				JSON.stringify(payload),
+				metadata.eventId,
+				metadata.aggregateId,
+				metadata.occurredOn,
+				metadata.correlationId ?? null,
+				metadata.causationId ?? null,
+			]),
+		);
+
+		return envelopes;
+	}
+
+	async *getEnvelopes({ streamId }: EventStream, filter?: EventFilter): AsyncGenerator<EventEnvelope[]> {
+		const connection = this.pool.getConnection();
+		const collection = EventCollection.get(filter?.pool);
+
+		const fromVersion = filter?.fromVersion;
+		const direction = filter?.direction || StreamReadingDirection.FORWARD;
+		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const query = `
+            SELECT *
+            FROM \`${collection}\`
+            WHERE stream_id = ?
+            ${fromVersion ? 'AND version >= ?' : ''}
+            ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
+            LIMIT ?
+        `;
+
+		const params = fromVersion ? [streamId, fromVersion, limit] : [streamId, limit];
+
+		const client = await connection;
+		const stream = client.queryStream(query, params);
+
+		try {
+			let batchedEvents: EventEnvelope[] = [];
+			for await (const {
+				event,
+				payload,
+				event_id,
+				aggregate_id,
+				version,
+				occurred_on,
+				correlation_id,
+				causation_id,
+			} of stream as unknown as MariaDBEventEntity[]) {
+				batchedEvents.push(
+					EventEnvelope.from(event, payload, {
+						eventId: event_id,
+						aggregateId: aggregate_id,
+						version,
+						occurredOn: occurred_on,
+						correlationId: correlation_id,
+						causationId: causation_id,
+					}),
+				);
+				if (batchedEvents.length === batch) {
+					yield batchedEvents;
+					batchedEvents = [];
+				}
+			}
+			if (batchedEvents.length > 0) {
+				yield batchedEvents;
+			}
+		} catch (e) {
+			stream.destroy();
+		} finally {
+			await client.release();
+		}
+	}
+
+	async getEnvelope({ streamId }: EventStream, version: number, pool?: IEventPool): Promise<EventEnvelope> {
+		const collection = EventCollection.get(pool);
+
+		const entities = await this.pool.query<MariaDBEventEntity>(
+			`SELECT * FROM \`${collection}\` WHERE stream_id = ? AND version = ?`,
+			[streamId, version],
+		);
+		const entity: MariaDBEventEntity = entities[0];
+
+		if (!entity) {
+			throw new EventNotFoundException(streamId, version);
+		}
+
+		return EventEnvelope.from(entity.event, entity.payload, {
+			eventId: entity.event_id,
+			aggregateId: entity.aggregate_id,
+			version: entity.version,
+			occurredOn: entity.occurred_on,
+			correlationId: entity.correlation_id,
+			causationId: entity.causation_id,
+		});
+	}
+}

--- a/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
@@ -1,0 +1,327 @@
+import {
+	AggregateRoot,
+	DEFAULT_BATCH_SIZE,
+	ISnapshot,
+	ISnapshotCollection,
+	ISnapshotPool,
+	LatestSnapshotFilter,
+	SnapshotCollection,
+	SnapshotEnvelope,
+	SnapshotFilter,
+	SnapshotNotFoundException,
+	SnapshotStore,
+	SnapshotStream,
+	StreamReadingDirection,
+} from '@ocoda/event-sourcing';
+import { type Pool, createPool } from 'mariadb';
+import { MariaDBSnapshotEntity, MariaDBSnapshotStoreConfig } from './interfaces';
+
+export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConfig> {
+	private pool: Pool;
+
+	async start(): Promise<ISnapshotCollection> {
+		this.logger.log('Starting store');
+		const { pool, ...params } = this.options;
+
+		this.pool = createPool(params);
+
+		const collection = SnapshotCollection.get(pool);
+
+		await this.pool.query(
+			`CREATE TABLE IF NOT EXISTS \`${collection}\` (
+                stream_id VARCHAR(255) NOT NULL,
+                version INT NOT NULL,
+                payload JSON NOT NULL,
+                snapshot_id VARCHAR(255) NOT NULL,
+                aggregate_id VARCHAR(255) NOT NULL,
+                registered_on TIMESTAMP NOT NULL,
+                aggregate_name VARCHAR(255) NOT NULL,
+                latest VARCHAR(255),
+                PRIMARY KEY (stream_id, version)
+            )`,
+		);
+
+		return collection;
+	}
+
+	async stop(): Promise<void> {
+		this.logger.log('Stopping store');
+		await this.pool.end();
+	}
+
+	async *getSnapshots<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		filter?: SnapshotFilter,
+	): AsyncGenerator<ISnapshot<A>[]> {
+		const connection = this.pool.getConnection();
+		const collection = SnapshotCollection.get(filter?.pool);
+
+		const fromVersion = filter?.fromVersion;
+		const direction = filter?.direction || StreamReadingDirection.FORWARD;
+		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const query = `
+	        SELECT payload
+	        FROM \`${collection}\`
+	        WHERE stream_id = ?
+	        ${fromVersion ? 'AND version >= ?' : ''}
+	        ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
+	        LIMIT ?
+	    `;
+
+		const params = fromVersion ? [streamId, fromVersion, limit] : [streamId, limit];
+
+		const client = await connection;
+		const stream = client.queryStream(query, params);
+
+		try {
+			let batchedEvents: ISnapshot<A>[] = [];
+			for await (const { payload } of stream as unknown as Pick<MariaDBSnapshotEntity<A>, 'payload'>[]) {
+				batchedEvents.push(payload);
+				if (batchedEvents.length === batch) {
+					yield batchedEvents;
+					batchedEvents = [];
+				}
+			}
+			if (batchedEvents.length > 0) {
+				yield batchedEvents;
+			}
+		} catch (e) {
+			stream.destroy();
+		} finally {
+			await client.release();
+		}
+	}
+
+	async getSnapshot<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		version: number,
+		pool?: ISnapshotPool,
+	): Promise<ISnapshot<A>> {
+		const collection = SnapshotCollection.get(pool);
+
+		const [entity] = await this.pool.query<Pick<MariaDBSnapshotEntity<A>, 'payload'>[]>(
+			`SELECT payload FROM \`${collection}\` WHERE stream_id = ? AND version = ?`,
+			[streamId, version],
+		);
+
+		if (!entity) {
+			throw new SnapshotNotFoundException(streamId, version);
+		}
+
+		return entity.payload;
+	}
+
+	async appendSnapshot<A extends AggregateRoot>(
+		{ streamId, aggregateId, aggregate }: SnapshotStream,
+		aggregateVersion: number,
+		snapshot: ISnapshot<A>,
+		pool?: ISnapshotPool,
+	): Promise<void> {
+		const collection = SnapshotCollection.get(pool);
+
+		const { payload, metadata } = SnapshotEnvelope.create<A>(snapshot, {
+			aggregateId,
+			version: aggregateVersion,
+		});
+
+		const lastStreamEntity = await this.getLastStreamEntity(collection, streamId);
+
+		if (lastStreamEntity) {
+			await this.pool.query(`UPDATE \`${collection}\` SET latest = null WHERE stream_id = ? AND version = ?`, [
+				lastStreamEntity.stream_id,
+				lastStreamEntity.version,
+			]);
+		}
+
+		await this.pool.query(`INSERT INTO \`${collection}\` VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, [
+			streamId,
+			metadata.version,
+			JSON.stringify(payload),
+			metadata.snapshotId,
+			metadata.aggregateId,
+			metadata.registeredOn,
+			aggregate,
+			`latest#${streamId}`,
+		]);
+	}
+
+	async getLastSnapshot<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		pool?: ISnapshotPool,
+	): Promise<ISnapshot<A>> {
+		const collection = SnapshotCollection.get(pool);
+
+		const entity = await this.getLastStreamEntity<A>(collection, streamId);
+
+		if (entity) {
+			return entity.payload;
+		}
+	}
+
+	async getLastEnvelope<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		pool?: ISnapshotPool,
+	): Promise<SnapshotEnvelope<A>> {
+		const collection = SnapshotCollection.get(pool);
+
+		const entity = await this.getLastStreamEntity<A>(collection, streamId);
+
+		if (entity) {
+			return SnapshotEnvelope.from<A>(entity.payload, {
+				snapshotId: entity.snapshot_id,
+				aggregateId: entity.aggregate_id,
+				registeredOn: entity.registered_on,
+				version: entity.version,
+			});
+		}
+	}
+
+	async *getEnvelopes<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		filter?: SnapshotFilter,
+	): AsyncGenerator<SnapshotEnvelope<A>[]> {
+		const connection = this.pool.getConnection();
+		const collection = SnapshotCollection.get(filter?.pool);
+
+		const fromVersion = filter?.fromVersion;
+		const direction = filter?.direction || StreamReadingDirection.FORWARD;
+		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const query = `
+	        SELECT payload, aggregate_id, registered_on, snapshot_id, version
+	        FROM \`${collection}\`
+	        WHERE stream_id = ?
+	        ${fromVersion ? 'AND version >= ?' : ''}
+	        ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
+	        LIMIT ?
+	    `;
+
+		const params = fromVersion ? [streamId, fromVersion, limit] : [streamId, limit];
+
+		const client = await connection;
+		const stream = client.queryStream(query, params);
+
+		try {
+			let batchedSnapshots: SnapshotEnvelope<A>[] = [];
+			for await (const { payload, aggregate_id, registered_on, snapshot_id, version } of stream as unknown as Omit<
+				MariaDBSnapshotEntity<A>,
+				'stream_id'
+			>[]) {
+				batchedSnapshots.push(
+					SnapshotEnvelope.from<A>(payload, {
+						aggregateId: aggregate_id,
+						registeredOn: registered_on,
+						snapshotId: snapshot_id,
+						version,
+					}),
+				);
+				if (batchedSnapshots.length === batch) {
+					yield batchedSnapshots;
+					batchedSnapshots = [];
+				}
+			}
+			if (batchedSnapshots.length > 0) {
+				yield batchedSnapshots;
+			}
+		} catch (e) {
+			stream.destroy();
+		} finally {
+			await client.release();
+		}
+	}
+
+	async getEnvelope<A extends AggregateRoot>(
+		{ streamId }: SnapshotStream,
+		version: number,
+		pool?: ISnapshotPool,
+	): Promise<SnapshotEnvelope<A>> {
+		const collection = SnapshotCollection.get(pool);
+
+		const [entity] = await this.pool.query<MariaDBSnapshotEntity<A>[]>(
+			`SELECT payload, aggregate_id, registered_on, snapshot_id, version FROM \`${collection}\` WHERE stream_id = ? AND version = ?`,
+			[streamId, version],
+		);
+
+		if (!entity) {
+			throw new SnapshotNotFoundException(streamId, version);
+		}
+
+		return SnapshotEnvelope.from<A>(entity.payload, {
+			aggregateId: entity.aggregate_id,
+			registeredOn: entity.registered_on,
+			snapshotId: entity.snapshot_id,
+			version: entity.version,
+		});
+	}
+
+	async *getLastEnvelopes<A extends AggregateRoot>(
+		aggregateName: string,
+		filter?: LatestSnapshotFilter,
+		pool?: ISnapshotPool,
+	): AsyncGenerator<SnapshotEnvelope<A>[]> {
+		const connection = this.pool.getConnection();
+		const collection = SnapshotCollection.get(pool);
+
+		const fromId = filter?.fromId;
+		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
+		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
+
+		const query = `
+	        SELECT payload, aggregate_id, registered_on, snapshot_id, version
+	        FROM \`${collection}\`
+	        WHERE aggregate_name = ?
+	        AND ${fromId ? 'latest >= ?' : "latest LIKE 'latest%'"}
+	        LIMIT ?
+	    `;
+
+		const params = fromId ? [aggregateName, fromId, limit] : [aggregateName, limit];
+
+		const client = await connection;
+		const stream = client.queryStream(query, params);
+
+		try {
+			let batchedSnapshots: SnapshotEnvelope<A>[] = [];
+			for await (const { payload, aggregate_id, registered_on, snapshot_id, version } of stream as unknown as Omit<
+				MariaDBSnapshotEntity<A>,
+				'stream_id'
+			>[]) {
+				batchedSnapshots.push(
+					SnapshotEnvelope.from<A>(payload, {
+						aggregateId: aggregate_id,
+						registeredOn: registered_on,
+						snapshotId: snapshot_id,
+						version,
+					}),
+				);
+				if (batchedSnapshots.length === batch) {
+					yield batchedSnapshots;
+					batchedSnapshots = [];
+				}
+			}
+			if (batchedSnapshots.length > 0) {
+				yield batchedSnapshots;
+			}
+		} catch (e) {
+			stream.destroy();
+		} finally {
+			await client.release();
+		}
+	}
+
+	private async getLastStreamEntity<A extends AggregateRoot>(
+		collection: string,
+		streamId: string,
+	): Promise<Omit<MariaDBSnapshotEntity<A>, 'aggregate_name' | 'latest'>> {
+		const [entity] = await this.pool.query<Omit<MariaDBSnapshotEntity<A>, 'aggregate_name' | 'latest'>[]>(
+			`SELECT stream_id, payload, aggregate_id, registered_on, snapshot_id, version FROM \`${collection}\` WHERE stream_id = ? ORDER BY version DESC LIMIT 1`,
+			[streamId],
+		);
+
+		if (entity) {
+			return entity;
+		}
+	}
+}

--- a/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
@@ -260,10 +260,9 @@ export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConf
 	async *getLastEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		const connection = this.pool.getConnection();
-		const collection = SnapshotCollection.get(pool);
+		const collection = SnapshotCollection.get(filter?.pool);
 
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;

--- a/packages/integration/mariadb/package.json
+++ b/packages/integration/mariadb/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@ocoda/event-sourcing-mariadb",
+	"version": "1.0.1-beta.0",
+	"description": "NestJS Event Sourcing Library (@mariadb)",
+	"author": "Dries Hooghe <dries@drieshooghe.com>",
+	"license": "MIT",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"scripts": {
+		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"test": "jest --config jest.config.js",
+		"test:ci": "jest --config jest.config.js --runInBand --coverage",
+		"ci": "biome ci",
+		"format": "biome format --write",
+		"lint": "biome check --write"
+	},
+	"bugs": {
+		"url": "https://github.com/ocoda/event-sourcing/issues"
+	},
+	"engines": {
+		"node": ">= 18.0.0"
+	},
+	"dependencies": {
+		"mariadb": "^3.3.1"
+	},
+	"peerDependencies": {
+		"@nestjs/core": "^10.0.0",
+		"@ocoda/event-sourcing": "workspace:*",
+		"reflect-metadata": "^0.2.0",
+		"rxjs": "^7.2.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "1.8.3",
+		"@faker-js/faker": "^8.0.0",
+		"@nestjs/common": "10.3.10",
+		"@nestjs/core": "10.3.10",
+		"@nestjs/platform-express": "10.3.10",
+		"@nestjs/testing": "10.3.10",
+		"@ocoda/event-sourcing-config": "workspace:*",
+		"@swc-node/register": "^1.5.2",
+		"@swc/core": "1.7.3",
+		"@swc/jest": "0.2.36",
+		"@types/jest": "29.5.12",
+		"@types/node": "20.16.5",
+		"jest": "29.7.0",
+		"jest-mock": "29.7.0",
+		"reflect-metadata": "0.2.2",
+		"rxjs": "7.8.1",
+		"typescript": "5.6.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ocoda/event-sourcing",
+		"directory": "packages/integration/mariadb"
+	}
+}

--- a/packages/integration/mariadb/tests/unit/mariadb.event-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.event-store.spec.ts
@@ -1,0 +1,314 @@
+import { NestApplication, NestFactory } from '@nestjs/core';
+import {
+	Aggregate,
+	AggregateRoot,
+	DefaultEventSerializer,
+	Event,
+	EventCollection,
+	EventEnvelope,
+	EventMap,
+	EventNotFoundException,
+	EventSourcingModule,
+	EventStore,
+	EventStream,
+	IEvent,
+	StreamReadingDirection,
+	UUID,
+} from '@ocoda/event-sourcing';
+import { MariaDBEventEntity, MariaDBEventStore, MariaDBEventStoreConfig } from '@ocoda/event-sourcing-mariadb';
+import { InMemorySnapshotStore } from '@ocoda/event-sourcing/integration/snapshot-store';
+import { Pool } from 'mariadb';
+
+class AccountId extends UUID {}
+
+@Aggregate({ streamName: 'account' })
+class Account extends AggregateRoot {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
+		super();
+	}
+}
+
+@Event('account-opened')
+class AccountOpenedEvent implements IEvent {}
+
+@Event('account-credited')
+class AccountCreditedEvent implements IEvent {
+	constructor(public readonly amount: number) {}
+}
+
+@Event('account-debited')
+class AccountDebitedEvent implements IEvent {
+	constructor(public readonly amount: number) {}
+}
+
+@Event('account-closed')
+class AccountClosedEvent implements IEvent {}
+
+describe(MariaDBEventStore, () => {
+	let app: NestApplication;
+	let eventStore: MariaDBEventStore;
+
+	let pool: Pool;
+	const publish = jest.fn(async () => Promise.resolve());
+
+	const eventMap = new EventMap();
+	eventMap.register(AccountOpenedEvent, DefaultEventSerializer.for(AccountOpenedEvent));
+	eventMap.register(AccountCreditedEvent, DefaultEventSerializer.for(AccountCreditedEvent));
+	eventMap.register(AccountDebitedEvent, DefaultEventSerializer.for(AccountDebitedEvent));
+	eventMap.register(AccountClosedEvent, DefaultEventSerializer.for(AccountClosedEvent));
+
+	const events = [
+		new AccountOpenedEvent(),
+		new AccountCreditedEvent(50),
+		new AccountDebitedEvent(20),
+		new AccountCreditedEvent(5),
+		new AccountDebitedEvent(35),
+		new AccountClosedEvent(),
+	];
+
+	const idAccountA = AccountId.generate();
+	const eventStreamAccountA = EventStream.for(Account, idAccountA);
+
+	const idAccountB = AccountId.generate();
+	const eventStreamAccountB = EventStream.for(Account, idAccountB);
+
+	const envelopesAccountA = [
+		EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+			aggregateId: idAccountA.value,
+			version: 1,
+		}),
+		EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+			aggregateId: idAccountA.value,
+			version: 2,
+		}),
+		EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+			aggregateId: idAccountA.value,
+			version: 3,
+		}),
+		EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+			aggregateId: idAccountA.value,
+			version: 4,
+		}),
+		EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+			aggregateId: idAccountA.value,
+			version: 5,
+		}),
+		EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+			aggregateId: idAccountA.value,
+			version: 6,
+		}),
+	];
+	const envelopesAccountB = [
+		EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
+			aggregateId: idAccountB.value,
+			version: 1,
+		}),
+		EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
+			aggregateId: idAccountB.value,
+			version: 2,
+		}),
+		EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
+			aggregateId: idAccountB.value,
+			version: 3,
+		}),
+		EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
+			aggregateId: idAccountB.value,
+			version: 4,
+		}),
+		EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
+			aggregateId: idAccountB.value,
+			version: 5,
+		}),
+		EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
+			aggregateId: idAccountB.value,
+			version: 6,
+		}),
+	];
+
+	beforeAll(async () => {
+		app = await NestFactory.create(
+			EventSourcingModule.forRootAsync<MariaDBEventStoreConfig>({
+				useFactory: () => ({
+					events: [AccountOpenedEvent, AccountCreditedEvent, AccountDebitedEvent, AccountClosedEvent],
+					eventStore: {
+						driver: MariaDBEventStore,
+						host: '127.0.0.1',
+						port: 3306,
+						user: 'mariadb',
+						password: 'mariadb',
+						database: 'mariadb',
+					},
+					snapshotStore: {
+						driver: InMemorySnapshotStore,
+					},
+				}),
+			}),
+		);
+		await app.init();
+
+		eventStore = app.get<MariaDBEventStore>(EventStore);
+		eventStore.publish = publish;
+
+		// biome-ignore lint/complexity/useLiteralKeys: Needed to check the internal workings of the event store
+		pool = eventStore['pool'];
+	});
+
+	afterAll(async () => {
+		await pool.query(`DROP TABLE IF EXISTS \`${EventCollection.get()}\``);
+		await app.close();
+	});
+
+	it('should append event envelopes', async () => {
+		await Promise.all([
+			eventStore.appendEvents(eventStreamAccountA, 3, events.slice(0, 3)),
+			eventStore.appendEvents(eventStreamAccountB, 3, events.slice(0, 3)),
+			eventStore.appendEvents(eventStreamAccountA, 6, events.slice(3)),
+			eventStore.appendEvents(eventStreamAccountB, 6, events.slice(3)),
+		]);
+
+		const entities = await pool.query<MariaDBEventEntity[]>(`
+		    SELECT * FROM \`${EventCollection.get()}\` ORDER BY version ASC
+		`);
+
+		const entitiesAccountA = entities.filter(
+			({ stream_id: entityStreamId }) => entityStreamId === eventStreamAccountA.streamId,
+		);
+		const entitiesAccountB = entities.filter(
+			({ stream_id: entityStreamId }) => entityStreamId === eventStreamAccountB.streamId,
+		);
+
+		expect(entities).toHaveLength(events.length * 2);
+		expect(entitiesAccountA).toHaveLength(events.length);
+		expect(entitiesAccountB).toHaveLength(events.length);
+
+		for (const [index, entity] of entitiesAccountA.entries()) {
+			expect(entity.stream_id).toEqual(eventStreamAccountA.streamId);
+			expect(entity.event).toEqual(envelopesAccountA[index].event);
+			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
+			expect(entity.aggregate_id).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(entity.occurred_on).toBeInstanceOf(Date);
+			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
+		}
+
+		for (const [index, entity] of entitiesAccountB.entries()) {
+			expect(entity.stream_id).toEqual(eventStreamAccountB.streamId);
+			expect(entity.event).toEqual(envelopesAccountB[index].event);
+			expect(entity.payload).toEqual(envelopesAccountB[index].payload);
+			expect(entity.aggregate_id).toEqual(envelopesAccountB[index].metadata.aggregateId);
+			expect(entity.occurred_on).toBeInstanceOf(Date);
+			expect(entity.version).toEqual(envelopesAccountB[index].metadata.version);
+		}
+
+		expect(publish).toHaveBeenCalledTimes(events.length * 2);
+	});
+
+	it('should retrieve a single event from a specified stream', async () => {
+		const resolvedEvent = await eventStore.getEvent(eventStreamAccountA, envelopesAccountA[3].metadata.version);
+
+		expect(resolvedEvent).toEqual(events[3]);
+	});
+
+	it('should filter events by stream', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA)) {
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events);
+	});
+
+	it('should filter events by stream and version', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			fromVersion: 3,
+		})) {
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events.slice(2));
+	});
+
+	it("should throw when an event isn't found in a specified stream", async () => {
+		const stream = EventStream.for(Account, AccountId.generate());
+		expect(eventStore.getEvent(stream, 5)).rejects.toThrow(new EventNotFoundException(stream.streamId, 5));
+	});
+
+	it('should retrieve events backwards', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events.slice().reverse());
+	});
+
+	it('should retrieve events backwards from a certain version', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			fromVersion: 4,
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events.slice(3).reverse());
+	});
+
+	it('should limit the returned events', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			limit: 3,
+		})) {
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events.slice(0, 3));
+	});
+
+	it('should batch the returned events', async () => {
+		const resolvedEvents: IEvent[] = [];
+		for await (const events of eventStore.getEvents(eventStreamAccountA, {
+			batch: 2,
+		})) {
+			expect(events.length).toBe(2);
+			resolvedEvents.push(...events);
+		}
+
+		expect(resolvedEvents).toEqual(events);
+	});
+
+	it('should retrieve a single event-envelope', async () => {
+		const { event, metadata, payload } = await eventStore.getEnvelope(
+			eventStreamAccountA,
+			envelopesAccountA[3].metadata.version,
+		);
+
+		expect(event).toEqual(envelopesAccountA[3].event);
+		expect(payload).toEqual(envelopesAccountA[3].payload);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.occurredOn).toBeInstanceOf(Date);
+		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
+	});
+
+	it('should retrieve event-envelopes', async () => {
+		const resolvedEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getEnvelopes(eventStreamAccountA)) {
+			resolvedEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedEnvelopes).toHaveLength(envelopesAccountA.length);
+
+		for (const [index, envelope] of resolvedEnvelopes.entries()) {
+			expect(envelope.event).toEqual(envelopesAccountA[index].event);
+			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.occurredOn).toBeInstanceOf(Date);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+		}
+	});
+});

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -1,0 +1,312 @@
+import { NestApplication, NestFactory } from '@nestjs/core';
+import {
+	Aggregate,
+	AggregateRoot,
+	EventSourcingModule,
+	ISnapshot,
+	SnapshotCollection,
+	SnapshotEnvelope,
+	SnapshotNotFoundException,
+	SnapshotStream,
+	StreamReadingDirection,
+	UUID,
+} from '@ocoda/event-sourcing';
+import { SnapshotStore } from '@ocoda/event-sourcing';
+import { MariaDBSnapshotEntity, MariaDBSnapshotStore, MariaDBSnapshotStoreConfig } from '@ocoda/event-sourcing-mariadb';
+import { InMemoryEventStore, InMemoryEventStoreConfig } from '@ocoda/event-sourcing/integration/event-store';
+import { Pool } from 'mariadb';
+
+class AccountId extends UUID {}
+class CustomerId extends UUID {}
+
+@Aggregate({ streamName: 'account' })
+class Account extends AggregateRoot {
+	constructor(
+		private readonly id: AccountId,
+		private readonly balance: number,
+	) {
+		super();
+	}
+}
+
+@Aggregate({ streamName: 'customer' })
+class Customer extends AggregateRoot {
+	constructor(
+		private readonly id: CustomerId,
+		private readonly name: string,
+	) {
+		super();
+	}
+}
+
+describe(MariaDBSnapshotStore, () => {
+	let app: NestApplication;
+	let snapshotStore: MariaDBSnapshotStore;
+
+	let pool: Pool;
+
+	const idAccountA = AccountId.generate();
+	const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
+	const snapshotsAccountA: ISnapshot<Account>[] = [
+		{ balance: 0 },
+		{ balance: 50 },
+		{ balance: 20 },
+		{ balance: 60 },
+		{ balance: 50 },
+	];
+	const idAccountB = AccountId.generate();
+	const snapshotStreamAccountB = SnapshotStream.for(Account, idAccountB);
+	const snapshotsAccountB: ISnapshot<Account>[] = [{ balance: 0 }, { balance: 10 }, { balance: 20 }, { balance: 30 }];
+	const customerSnapshot: ISnapshot<Customer> = { name: 'Hubert Farnsworth' };
+	const customerId = CustomerId.generate();
+	const snapshotStreamCustomer = SnapshotStream.for(Customer, customerId);
+
+	const envelopesAccountA = [
+		SnapshotEnvelope.create<Account>(snapshotsAccountA[0], {
+			aggregateId: idAccountA.value,
+			version: 1,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountA[1], {
+			aggregateId: idAccountA.value,
+			version: 10,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountA[2], {
+			aggregateId: idAccountA.value,
+			version: 20,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountA[3], {
+			aggregateId: idAccountA.value,
+			version: 30,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountA[4], {
+			aggregateId: idAccountA.value,
+			version: 40,
+		}),
+	];
+	const envelopesAccountB = [
+		SnapshotEnvelope.create<Account>(snapshotsAccountB[0], {
+			aggregateId: idAccountB.value,
+			version: 1,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountB[1], {
+			aggregateId: idAccountB.value,
+			version: 10,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountB[2], {
+			aggregateId: idAccountB.value,
+			version: 20,
+		}),
+		SnapshotEnvelope.create<Account>(snapshotsAccountB[3], {
+			aggregateId: idAccountB.value,
+			version: 30,
+		}),
+	];
+
+	beforeAll(async () => {
+		app = await NestFactory.create(
+			EventSourcingModule.forRootAsync<InMemoryEventStoreConfig, MariaDBSnapshotStoreConfig>({
+				useFactory: () => ({
+					events: [],
+					eventStore: {
+						driver: InMemoryEventStore,
+					},
+					snapshotStore: {
+						driver: MariaDBSnapshotStore,
+						host: '127.0.0.1',
+						port: 3306,
+						user: 'mariadb',
+						password: 'mariadb',
+						database: 'mariadb',
+					},
+				}),
+			}),
+		);
+		await app.init();
+
+		snapshotStore = app.get<MariaDBSnapshotStore>(SnapshotStore);
+
+		// biome-ignore lint/complexity/useLiteralKeys: Needed to check the internal workings of the event store
+		pool = snapshotStore['pool'];
+	});
+
+	afterAll(async () => {
+		await pool.query(`DROP TABLE IF EXISTS \`${SnapshotCollection.get()}\``);
+		await app.close();
+	});
+
+	it('should append snapshot envelopes', async () => {
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 1, snapshotsAccountA[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 1, snapshotsAccountB[0]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 10, snapshotsAccountA[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 10, snapshotsAccountB[1]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 20, snapshotsAccountA[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 20, snapshotsAccountB[2]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 30, snapshotsAccountA[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountB, 30, snapshotsAccountB[3]);
+		await snapshotStore.appendSnapshot(snapshotStreamAccountA, 40, snapshotsAccountA[4]);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 1, customerSnapshot);
+		await snapshotStore.appendSnapshot(snapshotStreamCustomer, 10, customerSnapshot);
+
+		const entities = await pool.query<MariaDBSnapshotEntity<Account>[]>(`
+            SELECT * FROM \`${SnapshotCollection.get()}\` ORDER BY version ASC
+        `);
+
+		const entitiesAccountA = entities.filter(
+			({ stream_id: entityStreamId }) => entityStreamId === snapshotStreamAccountA.streamId,
+		);
+		const entitiesAccountB = entities.filter(
+			({ stream_id: entityStreamId }) => entityStreamId === snapshotStreamAccountB.streamId,
+		);
+		const entitiesCustomer = entities.filter(
+			({ stream_id: entityStreamId }) => entityStreamId === snapshotStreamCustomer.streamId,
+		);
+		expect(entitiesAccountA).toHaveLength(snapshotsAccountA.length);
+		expect(entitiesAccountB).toHaveLength(snapshotsAccountB.length);
+		expect(entitiesCustomer).toHaveLength(2);
+		for (const [index, entity] of entitiesAccountA.entries()) {
+			expect(entity.stream_id).toEqual(snapshotStreamAccountA.streamId);
+			expect(entity.payload).toEqual(envelopesAccountA[index].payload);
+			expect(entity.aggregate_id).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(entity.registered_on).toBeInstanceOf(Date);
+			expect(entity.version).toEqual(envelopesAccountA[index].metadata.version);
+		}
+	});
+
+	it('should retrieve a single snapshot from a specified stream', async () => {
+		const resolvedSnapshot = await snapshotStore.getSnapshot(
+			snapshotStreamAccountA,
+			envelopesAccountA[1].metadata.version,
+		);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[1]);
+	});
+
+	it('should retrieve snapshots by stream', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA)) {
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA);
+	});
+
+	it('should filter snapshots by stream and version', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			fromVersion: 30,
+		})) {
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(3));
+	});
+
+	it("should throw when a snapshot isn't found in a specified stream", () => {
+		const stream = SnapshotStream.for(Account, AccountId.generate());
+		expect(snapshotStore.getSnapshot(stream, 20)).rejects.toThrow(new SnapshotNotFoundException(stream.streamId, 20));
+	});
+
+	it('should retrieve snapshots backwards', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice().reverse());
+	});
+
+	it('should retrieve snapshots backwards from a certain version', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, {
+			fromVersion: envelopesAccountA[1].metadata.version,
+			direction: StreamReadingDirection.BACKWARD,
+		})) {
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(
+			snapshotsAccountA.filter((_, index) => (index + 1) * 10 >= envelopesAccountA[2].metadata.version).reverse(),
+		);
+	});
+
+	it('should limit the returned snapshots', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
+	});
+
+	it('should batch the returned snapshots', async () => {
+		const resolvedSnapshots: ISnapshot<Account>[] = [];
+		for await (const snapshots of snapshotStore.getSnapshots(snapshotStreamAccountA, { limit: 2 })) {
+			expect(snapshots.length).toBe(2);
+			resolvedSnapshots.push(...snapshots);
+		}
+		expect(resolvedSnapshots).toEqual(snapshotsAccountA.slice(0, 2));
+	});
+
+	it('should retrieve the last snapshot', async () => {
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(snapshotStreamAccountA);
+		expect(resolvedSnapshot).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+	});
+
+	it('should return undefined if there is no last snapshot', async () => {
+		@Aggregate({ streamName: 'foo' })
+		class Foo extends AggregateRoot {}
+		const resolvedSnapshot = await snapshotStore.getLastSnapshot(SnapshotStream.for(Foo, UUID.generate()));
+		expect(resolvedSnapshot).toBeUndefined();
+	});
+
+	it('should retrieve snapshot-envelopes', async () => {
+		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {
+			resolvedEnvelopes.push(...envelopes);
+		}
+		expect(resolvedEnvelopes).toHaveLength(envelopesAccountA.length);
+		for (const [index, envelope] of resolvedEnvelopes.entries()) {
+			expect(envelope.payload).toEqual(envelopesAccountA[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(envelopesAccountA[index].metadata.aggregateId);
+			expect(envelope.metadata.registeredOn).toBeInstanceOf(Date);
+			expect(envelope.metadata.version).toEqual(envelopesAccountA[index].metadata.version);
+		}
+	});
+
+	it('should retrieve a single snapshot-envelope', async () => {
+		const { metadata, payload } = await snapshotStore.getEnvelope(
+			snapshotStreamAccountA,
+			envelopesAccountA[3].metadata.version,
+		);
+		expect(payload).toEqual(envelopesAccountA[3].payload);
+		expect(metadata.aggregateId).toEqual(envelopesAccountA[3].metadata.aggregateId);
+		expect(metadata.registeredOn).toBeInstanceOf(Date);
+		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
+	});
+
+	it('should retrieve the last snapshot-envelope', async () => {
+		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
+		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
+		expect(payload).toEqual(lastEnvelope.payload);
+		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);
+		expect(metadata.registeredOn).toBeInstanceOf(Date);
+		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
+	});
+
+	it('should retrieve the last snapshot-envelopes', async () => {
+		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+			resolvedEnvelopes.push(...envelopes);
+		}
+		expect(resolvedEnvelopes).toHaveLength(2);
+		const [envelopeAccountB, envelopeAccountA] = [
+			envelopesAccountB[envelopesAccountB.length - 1],
+			envelopesAccountA[envelopesAccountA.length - 1],
+		];
+		resolvedEnvelopes = resolvedEnvelopes.sort((a, b) => (a.metadata.version > b.metadata.version ? 1 : -1));
+		expect(resolvedEnvelopes[0].payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedEnvelopes[0].metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedEnvelopes[0].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[0].metadata.version).toEqual(envelopeAccountB.metadata.version);
+		expect(resolvedEnvelopes[1].payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
+	});
+});

--- a/packages/integration/mariadb/tsconfig.build.json
+++ b/packages/integration/mariadb/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@ocoda/event-sourcing-config/typescript/module.build.json",
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"rootDir": "./lib",
+		"outDir": "dist"
+	},
+	"include": ["lib/**/*.ts"]
+}

--- a/packages/integration/mariadb/tsconfig.json
+++ b/packages/integration/mariadb/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@ocoda/event-sourcing-config/typescript/module.json",
+	"include": ["index.ts", "index.d.ts", "lib/**/*.ts", "tests/**/*.ts"],
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"paths": {
+			"@ocoda/event-sourcing": ["../../core/lib"],
+			"@ocoda/event-sourcing/*": ["../../core/lib/*"],
+			"@ocoda/event-sourcing-mariadb": ["../../integration/mariadb/lib"],
+			"@ocoda/event-sourcing-mariadb/*": ["../../integration/mariadb/lib/*"]
+		}
+	}
+}

--- a/packages/integration/mariadb/turbo.json
+++ b/packages/integration/mariadb/turbo.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"dependsOn": ["@ocoda/event-sourcing#build"],
+			"outputs": ["dist/integration/mariadb/**"]
+		},
+		"test": {},
+		"test:ci": {},
+		"lint": {},
+		"format": {}
+	}
+}

--- a/packages/integration/mariadb/turbo.json
+++ b/packages/integration/mariadb/turbo.json
@@ -4,7 +4,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["@ocoda/event-sourcing#build"],
-			"outputs": ["dist/integration/mariadb/**"]
+			"outputs": ["dist/**"]
 		},
 		"test": {},
 		"test:ci": {},

--- a/packages/integration/mongodb/lib/mongodb-snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb-snapshot-store.ts
@@ -236,9 +236,8 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 	async *getLastEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
-		const collection = SnapshotCollection.get(pool);
+		const collection = SnapshotCollection.get(filter?.pool);
 
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;

--- a/packages/integration/mongodb/turbo.json
+++ b/packages/integration/mongodb/turbo.json
@@ -4,7 +4,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["@ocoda/event-sourcing#build"],
-			"outputs": ["dist/integration/mongodb/**"]
+			"outputs": ["dist/**"]
 		},
 		"test": {},
 		"test:ci": {},

--- a/packages/integration/postgres/lib/postgres-event-store.ts
+++ b/packages/integration/postgres/lib/postgres-event-store.ts
@@ -62,7 +62,7 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 
 		const query = `
             SELECT event, payload
-            FROM ${collection}
+            FROM "${collection}"
             WHERE stream_id = $1
             ${fromVersion ? 'AND version >= $2' : ''}
             ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}

--- a/packages/integration/postgres/lib/postgres-event-store.ts
+++ b/packages/integration/postgres/lib/postgres-event-store.ts
@@ -149,7 +149,7 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 		// Build the SQL query with parameterized inputs
 		const query = `
             SELECT *
-            FROM ${collection}
+            FROM "${collection}"
             WHERE stream_id = $1
             ${fromVersion ? 'AND version >= $2' : ''}
             ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}

--- a/packages/integration/postgres/lib/postgres-snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres-snapshot-store.ts
@@ -264,9 +264,8 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 	async *getLastEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: LatestSnapshotFilter,
-		pool?: ISnapshotPool,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
-		const collection = SnapshotCollection.get(pool);
+		const collection = SnapshotCollection.get(filter?.pool);
 
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;

--- a/packages/integration/postgres/lib/postgres-snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres-snapshot-store.ts
@@ -66,7 +66,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 
 		const query = `
 	        SELECT payload
-	        FROM ${collection}
+	        FROM "${collection}"
 	        WHERE stream_id = $1
 	        ${fromVersion ? 'AND version >= $2' : ''}
 	        ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
@@ -198,7 +198,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 
 		const query = `
 	        SELECT payload, aggregate_id, registered_on, snapshot_id, version
-	        FROM ${collection}
+	        FROM "${collection}"
 	        WHERE stream_id = $1
 	        ${fromVersion ? 'AND version >= $2' : ''}
 	        ORDER BY version ${direction === StreamReadingDirection.FORWARD ? 'ASC' : 'DESC'}
@@ -274,7 +274,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 
 		const query = `
             SELECT payload, aggregate_id, registered_on, snapshot_id, version
-            FROM ${collection}
+            FROM "${collection}"
             WHERE aggregate_name = $1
             AND ${fromId ? 'latest >= $2' : "latest LIKE 'latest%'"}
             ORDER BY latest DESC

--- a/packages/integration/postgres/turbo.json
+++ b/packages/integration/postgres/turbo.json
@@ -4,7 +4,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["@ocoda/event-sourcing#build"],
-			"outputs": ["dist/integration/postgres/**"]
+			"outputs": ["dist/**"]
 		},
 		"test": {},
 		"test:ci": {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,64 @@ importers:
         specifier: 5.6.2
         version: 5.6.2
 
+  packages/integration/mariadb:
+    dependencies:
+      mariadb:
+        specifier: ^3.3.1
+        version: 3.3.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 1.8.3
+        version: 1.8.3
+      '@faker-js/faker':
+        specifier: ^8.0.0
+        version: 8.4.1
+      '@nestjs/common':
+        specifier: 10.3.10
+        version: 10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core':
+        specifier: 10.3.10
+        version: 10.3.10(@nestjs/common@10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.10)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/platform-express':
+        specifier: 10.3.10
+        version: 10.3.10(@nestjs/common@10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.10)
+      '@nestjs/testing':
+        specifier: 10.3.10
+        version: 10.3.10(@nestjs/common@10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.10(@nestjs/common@10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.10)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.10(@nestjs/common@10.3.10(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.10))
+      '@ocoda/event-sourcing-config':
+        specifier: workspace:*
+        version: link:../../config
+      '@swc-node/register':
+        specifier: ^1.5.2
+        version: 1.10.9(@swc/core@1.7.3)(@swc/types@0.1.12)(typescript@5.6.2)
+      '@swc/core':
+        specifier: 1.7.3
+        version: 1.7.3
+      '@swc/jest':
+        specifier: 0.2.36
+        version: 0.2.36(@swc/core@1.7.3)
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 20.16.5
+        version: 20.16.5
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.16.5)
+      jest-mock:
+        specifier: 29.7.0
+        version: 29.7.0
+      reflect-metadata:
+        specifier: 0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
+
   packages/integration/mongodb:
     dependencies:
       '@ocoda/event-sourcing':
@@ -537,11 +595,6 @@ packages:
   '@babel/highlight@7.23.4':
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.18.9':
-    resolution: {integrity: sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.23.9':
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
@@ -1314,6 +1367,9 @@ packages:
   '@types/babel__traverse@7.17.1':
     resolution: {integrity: sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==}
 
+  '@types/geojson@7946.0.14':
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
+
   '@types/graceful-fs@4.1.5':
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
 
@@ -1758,6 +1814,10 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2081,6 +2141,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -2494,6 +2558,9 @@ packages:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -2508,6 +2575,10 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  mariadb@3.3.1:
+    resolution: {integrity: sha512-L8bh4iuZU3J8H7Co7rQ6OY9FDLItAN1rGy8kPA7Dyxo8AiHADuuONoypKKp1pE09drs6e5LR7UW9luLZ/A4znA==}
+    engines: {node: '>= 14'}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3999,10 +4070,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  '@babel/parser@7.18.9':
-    dependencies:
-      '@babel/types': 7.23.9
-
   '@babel/parser@7.23.9':
     dependencies:
       '@babel/types': 7.23.9
@@ -4957,6 +5024,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.23.9
 
+  '@types/geojson@7946.0.14': {}
+
   '@types/graceful-fs@4.1.5':
     dependencies:
       '@types/node': 20.16.5
@@ -5428,6 +5497,8 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  denque@2.1.0: {}
+
   depd@2.0.0: {}
 
   deprecation@2.3.1: {}
@@ -5790,6 +5861,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.2.4: {}
@@ -5934,7 +6009,7 @@ snapshots:
   istanbul-lib-instrument@6.0.1:
     dependencies:
       '@babel/core': 7.18.9
-      '@babel/parser': 7.18.9
+      '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 7.6.3
@@ -6339,6 +6414,8 @@ snapshots:
 
   lowercase-keys@3.0.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@7.18.3: {}
 
   macos-release@3.1.0: {}
@@ -6350,6 +6427,14 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  mariadb@3.3.1:
+    dependencies:
+      '@types/geojson': 7946.0.14
+      '@types/node': 20.16.5
+      denque: 2.1.0
+      iconv-lite: 0.6.3
+      lru-cache: 10.4.3
 
   media-typer@0.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
 
   packages/integration/mariadb:
     dependencies:
+      '@ocoda/event-sourcing':
+        specifier: workspace:*
+        version: link:../../core
       mariadb:
         specifier: ^3.3.1
         version: 3.3.1


### PR DESCRIPTION
- **✨ add the boilerplate code for a mariadb integration**
- **:whale: add a mariadb container**
- **🩹 make sure the collection is wrapped in quotes**
- **✨ add a mariadb event-store integration**
- **🗃️ optimize postgres queries**
- **🗃️ optimize mariadb event-store queries**
- **🗃️ make postgres table selection safe**
- **✨ add a mariadb snapshot-store integration**
- **👷 add mariadb to the testing matrix**
- **:recycle: move the pool filter inside the LatestSnapshotFilter**
- **:recycle: fix turbo build output paths**

# Description

- Adds a MariaDB integration
- Optimizes Postgres queries
- Moves the pool filter inside of the LatestSnapshotFilter
- Fixes the turbo build output paths

Fixes #287

## Type of change

_Please delete options that are not relevant._

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


