### PR TITLE
[290] Customize pool creation

### DIFF
--- a/example/src/app.module.ts
+++ b/example/src/app.module.ts
@@ -24,12 +24,10 @@ import { AccountController } from './application/account.controller';
 				events: [...Events],
 				eventStore: {
 					driver: MongoDBEventStore,
-					pool: 'example-events',
 					url: 'mongodb://127.0.0.1:27017',
 				},
 				snapshotStore: {
 					driver: MongoDBSnapshotStore,
-					pool: 'example-snapshots',
 					url: 'mongodb://127.0.0.1:27017',
 				},
 			}),

--- a/packages/core/lib/event-sourcing.module.ts
+++ b/packages/core/lib/event-sourcing.module.ts
@@ -112,10 +112,10 @@ export class EventSourcingModule implements OnModuleInit {
 	) {}
 
 	async onModuleInit() {
-		await Promise.all([this.eventStore.start(), this.snapshotStore.start()]); // TODO: Add error handling
+		await Promise.all([this.eventStore.connect(), this.snapshotStore.connect()]); // TODO: Add error handling
 	}
 
 	async onModuleDestroy() {
-		await Promise.all([this.eventStore.stop(), this.snapshotStore.stop()]); // TODO: Add error handling
+		await Promise.all([this.eventStore.disconnect(), this.snapshotStore.disconnect()]); // TODO: Add error handling
 	}
 }

--- a/packages/core/lib/event-store.ts
+++ b/packages/core/lib/event-store.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { StreamReadingDirection } from './constants';
 import { EventMap } from './event-map';
-import { EventSourcingModuleOptions, EventStoreDriver, IEvent, IEventPool } from './interfaces';
+import { EventSourcingModuleOptions, EventStoreDriver, IEvent, IEventCollection, IEventPool } from './interfaces';
 import { EventEnvelope, EventStream } from './models';
 
 export interface EventFilter {
@@ -32,7 +32,7 @@ export interface EventFilter {
 }
 
 export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eventStore'], 'driver'>>
-	implements EventStoreDriver<TOptions>
+	implements EventStoreDriver
 {
 	protected readonly logger = new Logger(this.constructor.name);
 	protected _publish: (envelope: EventEnvelope<IEvent>) => any;
@@ -62,8 +62,10 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 		this._publish = fn;
 	}
 
-	public abstract start(): unknown | Promise<unknown>;
-	public abstract stop(): void | Promise<void>;
+	public abstract connect(): void | Promise<void>;
+	public abstract disconnect(): void | Promise<void>;
+
+	public abstract ensureCollection(pool?: string): IEventCollection | Promise<unknown>;
 
 	abstract getEvents(eventStream: EventStream, filter?: EventFilter): AsyncGenerator<IEvent[]>;
 	abstract getEvent(eventStream: EventStream, version: number, pool?: IEventPool): IEvent | Promise<IEvent>;

--- a/packages/core/lib/integration/event-store/in-memory.event-store.ts
+++ b/packages/core/lib/integration/event-store/in-memory.event-store.ts
@@ -23,19 +23,22 @@ export interface InMemoryEventStoreConfig extends EventStoreConfig {
 }
 
 export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
-	public readonly collections: Map<IEventCollection, InMemoryEventEntity[]> = new Map();
+	public collections: Map<IEventCollection, InMemoryEventEntity[]>;
 
-	public start(): void {
+	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-		const { pool } = this.options;
-
-		const collection = EventCollection.get(pool);
-		this.collections.set(collection, []);
+        this.collections = new Map();
 	}
 
-	public stop(): void {
+	public async disconnect(): Promise<void> {
 		this.logger.log('Stopping store');
 		this.collections.clear();
+	}
+
+	public async ensureCollection(pool?: IEventPool): Promise<IEventCollection> {
+		const collection = EventCollection.get(pool);
+		this.collections.set(collection, []);
+        return collection;
 	}
 
 	async *getEvents({ streamId }: EventStream, filter?: EventFilter): AsyncGenerator<IEvent[]> {

--- a/packages/core/lib/integration/event-store/in-memory.event-store.ts
+++ b/packages/core/lib/integration/event-store/in-memory.event-store.ts
@@ -27,7 +27,7 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 
 	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-        this.collections = new Map();
+		this.collections = new Map();
 	}
 
 	public async disconnect(): Promise<void> {
@@ -38,7 +38,7 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 	public async ensureCollection(pool?: IEventPool): Promise<IEventCollection> {
 		const collection = EventCollection.get(pool);
 		this.collections.set(collection, []);
-        return collection;
+		return collection;
 	}
 
 	async *getEvents({ streamId }: EventStream, filter?: EventFilter): AsyncGenerator<IEvent[]> {

--- a/packages/core/lib/interfaces/aggregate/snapshot-store-config.interface.ts
+++ b/packages/core/lib/interfaces/aggregate/snapshot-store-config.interface.ts
@@ -3,5 +3,4 @@ import { SnapshotStoreDriver } from './snapshot-store.interface';
 
 export interface SnapshotStoreConfig {
 	driver: Type<SnapshotStoreDriver>;
-	pool?: string;
 }

--- a/packages/core/lib/interfaces/aggregate/snapshot-store-config.interface.ts
+++ b/packages/core/lib/interfaces/aggregate/snapshot-store-config.interface.ts
@@ -3,4 +3,10 @@ import { SnapshotStoreDriver } from './snapshot-store.interface';
 
 export interface SnapshotStoreConfig {
 	driver: Type<SnapshotStoreDriver>;
+	/**
+	 * Creates a snapshot collection with the default pool name ('snapshots').
+	 * For multi-tenant setups, you can provide a pool name to separate snapshots with `snapshotStore.ensureCollection(pool?: ISnapshotPool)`.
+	 * @default true
+	 */
+	useDefaultPool?: boolean;
 }

--- a/packages/core/lib/interfaces/aggregate/snapshot-store.interface.ts
+++ b/packages/core/lib/interfaces/aggregate/snapshot-store.interface.ts
@@ -1,4 +1,8 @@
-export interface SnapshotStoreDriver<TOptions = any> {
-	start(options: TOptions): unknown | Promise<unknown>;
-	stop(): void | Promise<void>;
+import { ISnapshotCollection } from './snapshot-collection.type';
+import { ISnapshotPool } from './snapshot-pool.type';
+
+export interface SnapshotStoreDriver {
+	connect(): void | Promise<void>;
+	disconnect(): void | Promise<void>;
+	ensureCollection(pool?: ISnapshotPool): ISnapshotCollection | Promise<ISnapshotCollection>;
 }

--- a/packages/core/lib/interfaces/events/event-store-config.interface.ts
+++ b/packages/core/lib/interfaces/events/event-store-config.interface.ts
@@ -3,5 +3,4 @@ import { EventStoreDriver } from './event-store.interface';
 
 export interface EventStoreConfig {
 	driver: Type<EventStoreDriver>;
-	pool?: string;
 }

--- a/packages/core/lib/interfaces/events/event-store-config.interface.ts
+++ b/packages/core/lib/interfaces/events/event-store-config.interface.ts
@@ -3,4 +3,10 @@ import { EventStoreDriver } from './event-store.interface';
 
 export interface EventStoreConfig {
 	driver: Type<EventStoreDriver>;
+	/**
+	 * Creates an event collection with the default pool name ('events').
+	 * For multi-tenant setups, you can provide a pool name to separate events with `eventStore.ensureCollection(pool?: IEventPool)`.
+	 * @default true
+	 */
+	useDefaultPool?: boolean;
 }

--- a/packages/core/lib/interfaces/events/event-store.interface.ts
+++ b/packages/core/lib/interfaces/events/event-store.interface.ts
@@ -1,4 +1,7 @@
-export interface EventStoreDriver<TOptions = any> {
-	start(options: TOptions): unknown | Promise<unknown>;
-	stop(): void | Promise<void>;
+import { IEventPool } from './event-pool.type';
+
+export interface EventStoreDriver {
+	connect(): void | Promise<void>;
+	disconnect(): void | Promise<void>;
+	ensureCollection(pool?: IEventPool): unknown | Promise<unknown>;
 }

--- a/packages/core/tests/unit/integration/event-store/in-memory.event-store.spec.ts
+++ b/packages/core/tests/unit/integration/event-store/in-memory.event-store.spec.ts
@@ -71,7 +71,8 @@ describe(InMemoryEventStore, () => {
 	beforeAll(() => {
 		eventStore = new InMemoryEventStore(eventMap, { driver: InMemoryEventStore });
 		eventStore.publish = publish;
-		eventStore.start();
+		eventStore.connect();
+		eventStore.ensureCollection();
 
 		envelopesAccountA = [
 			EventEnvelope.create('account-opened', eventMap.serializeEvent(events[0]), {
@@ -127,7 +128,7 @@ describe(InMemoryEventStore, () => {
 		];
 	});
 
-	afterAll(() => eventStore.stop());
+	afterAll(() => eventStore.disconnect());
 
 	it('should append event envelopes', async () => {
 		await Promise.all([

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -59,7 +59,8 @@ describe(InMemorySnapshotStore, () => {
 
 	beforeAll(() => {
 		snapshotStore = new InMemorySnapshotStore({ driver: InMemorySnapshotStore });
-		snapshotStore.start();
+		snapshotStore.connect();
+		snapshotStore.ensureCollection();
 
 		envelopesAccountA = [
 			SnapshotEnvelope.create<Account>(snapshotsAccountA[0], {
@@ -103,7 +104,7 @@ describe(InMemorySnapshotStore, () => {
 		];
 	});
 
-	afterAll(() => snapshotStore.stop());
+	afterAll(() => snapshotStore.disconnect());
 
 	it('should append snapshot envelopes', () => {
 		snapshotStore.appendSnapshot(snapshotStreamAccountA, 1, snapshotsAccountA[0]);

--- a/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb-snapshot-store.ts
@@ -19,12 +19,17 @@ import { MariaDBSnapshotEntity, MariaDBSnapshotStoreConfig } from './interfaces'
 export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConfig> {
 	private pool: Pool;
 
-	async start(): Promise<ISnapshotCollection> {
+	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-		const { pool, ...params } = this.options;
+		this.pool = createPool(this.options);
+	}
 
-		this.pool = createPool(params);
+	public async disconnect(): Promise<void> {
+		this.logger.log('Stopping store');
+		await this.pool.end();
+	}
 
+	public async ensureCollection(pool?: ISnapshotPool): Promise<ISnapshotCollection> {
 		const collection = SnapshotCollection.get(pool);
 
 		await this.pool.query(

--- a/packages/integration/mongodb/lib/mongodb-snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb-snapshot-store.ts
@@ -20,13 +20,19 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 	private client: MongoClient;
 	private database: Db;
 
-	async start(): Promise<ISnapshotCollection> {
+	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-		const { url, pool, ...options } = this.options;
-
-		this.client = await new MongoClient(url, options).connect();
+		const { url, ...params } = this.options;
+		this.client = await new MongoClient(url, params).connect();
 		this.database = this.client.db();
+	}
 
+	public async disconnect(): Promise<void> {
+		this.logger.log('Stopping store');
+		await this.client.close();
+	}
+
+	public async ensureCollection(pool?: ISnapshotPool): Promise<ISnapshotCollection> {
 		const collection = SnapshotCollection.get(pool);
 
 		const [existingCollection] = await this.database.listCollections({ name: collection }).toArray();

--- a/packages/integration/mongodb/tests/unit/mongodb.event-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.event-store.spec.ts
@@ -136,12 +136,8 @@ describe(MongoDBEventStore, () => {
 					eventStore: {
 						driver: MongoDBEventStore,
 						url: 'mongodb://localhost:27017',
-						pool: 'test-events',
 					},
-					snapshotStore: {
-						driver: InMemorySnapshotStore,
-						pool: 'test-snapshots',
-					},
+					snapshotStore: { driver: InMemorySnapshotStore },
 				}),
 			}),
 		);

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -106,14 +106,10 @@ describe(MongoDBSnapshotStore, () => {
 			EventSourcingModule.forRootAsync<InMemoryEventStoreConfig, MongoDBSnapshotStoreConfig>({
 				useFactory: () => ({
 					events: [],
-					eventStore: {
-						driver: InMemoryEventStore,
-						pool: 'test-events',
-					},
+					eventStore: { driver: InMemoryEventStore },
 					snapshotStore: {
 						driver: MongoDBSnapshotStore,
 						url: 'mongodb://localhost:27017',
-						pool: 'test-snapshots',
 					},
 				}),
 			}),

--- a/packages/integration/postgres/lib/postgres-event-store.ts
+++ b/packages/integration/postgres/lib/postgres-event-store.ts
@@ -19,13 +19,19 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 	private pool: Pool;
 	private client: PoolClient;
 
-	async start(): Promise<IEventCollection> {
+	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-		const { pool, ...params } = this.options;
-
-		this.pool = new Pool(params);
+		this.pool = new Pool(this.options);
 		this.client = await this.pool.connect();
+	}
 
+	public async disconnect(): Promise<void> {
+		this.logger.log('Stopping store');
+		this.client.release();
+		await this.pool.end();
+	}
+
+	public async ensureCollection(pool?: IEventPool): Promise<IEventCollection> {
 		const collection = EventCollection.get(pool);
 
 		await this.client.query(
@@ -44,12 +50,6 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 		);
 
 		return collection;
-	}
-
-	async stop(): Promise<void> {
-		this.logger.log('Stopping store');
-		this.client.release();
-		await this.pool.end();
 	}
 
 	async *getEvents({ streamId }: EventStream, filter?: EventFilter): AsyncGenerator<IEvent[]> {

--- a/packages/integration/postgres/lib/postgres-snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres-snapshot-store.ts
@@ -21,13 +21,19 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 	private pool: Pool;
 	private client: PoolClient;
 
-	async start(): Promise<ISnapshotCollection> {
+    public async connect(): Promise<void> {
 		this.logger.log('Starting store');
-		const { pool, ...params } = this.options;
-
-		this.pool = new Pool(params);
+		this.pool = new Pool(this.options);
 		this.client = await this.pool.connect();
+	}
 
+	public async disconnect(): Promise<void> {
+		this.logger.log('Stopping store');
+		this.client.release();
+		await this.pool.end();
+	}
+
+	public async ensureCollection(pool?: ISnapshotPool): Promise<ISnapshotCollection> {
 		const collection = SnapshotCollection.get(pool);
 
 		await this.client.query(

--- a/packages/integration/postgres/lib/postgres-snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres-snapshot-store.ts
@@ -21,7 +21,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 	private pool: Pool;
 	private client: PoolClient;
 
-    public async connect(): Promise<void> {
+	public async connect(): Promise<void> {
 		this.logger.log('Starting store');
 		this.pool = new Pool(this.options);
 		this.client = await this.pool.connect();


### PR DESCRIPTION
- **:recycle: refactor how the event- and snapshot stores get spun up**
- **:sparkles: create a default event- and snapshot-pool if not explicitly disabled**

# Description

Adds the option to not create default event- and snapshot-collections.

Fixes #290

