### PR TITLE
[289] Create Mongo snapshot-store indexes in a single request

### DIFF
--- a/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
@@ -42,8 +42,10 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 		}
 
 		const snapshotCollection = await this.database.createCollection(collection);
-		await snapshotCollection.createIndex({ streamId: 1, version: 1 }, { unique: true });
-		await snapshotCollection.createIndex({ aggregateName: 1, latest: 1 }, { unique: false });
+		await snapshotCollection.createIndexes([
+			{ key: { streamId: 1, version: 1 }, unique: true },
+			{ key: { aggregateName: 1, latest: 1 }, unique: false },
+		]);
 
 		return collection;
 	}


### PR DESCRIPTION
# Description

Creates the required MongoDB snapshot-store indexes in a single request instead of two.

Fixes #289

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

