### PR TITLE
[302] Get many last snapshots

### DIFF
--- a/packages/core/lib/event-store.ts
+++ b/packages/core/lib/event-store.ts
@@ -38,24 +38,78 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 		});
 	}
 
+	/**
+	 * Set the publish function.
+	 * @param fn The publish function.
+	 */
 	set publish(fn: (envelope: EventEnvelope<IEvent>) => any) {
 		this._publish = fn;
 	}
 
+	/**
+	 * Connect to the event store.
+	 */
 	public abstract connect(): void | Promise<void>;
+
+	/**
+	 * Disconnect from the event store
+	 */
 	public abstract disconnect(): void | Promise<void>;
 
-	public abstract ensureCollection(pool?: string): IEventCollection | Promise<unknown>;
+	/**
+	 * Ensure the event collection exists.
+	 * @param pool The event pool.
+	 * @returns The event collection.
+	 */
+	public abstract ensureCollection(pool?: string): IEventCollection | Promise<IEventCollection>;
 
+	/**
+	 * Get events from the event stream.
+	 * @param eventStream The event stream.
+	 * @param filter The event filter.
+	 * @returns The events.
+	 */
 	abstract getEvents(eventStream: EventStream, filter?: IEventFilter): AsyncGenerator<IEvent[]>;
+
+	/**
+	 * Get an event from the event stream.
+	 * @param eventStream The event stream.
+	 * @param version The event version.
+	 * @param pool The event pool.
+	 * @returns The event.
+	 */
 	abstract getEvent(eventStream: EventStream, version: number, pool?: IEventPool): IEvent | Promise<IEvent>;
+
+	/**
+	 * Append events to the event stream.
+	 * @param eventStream The event stream.
+	 * @param version The event version.
+	 * @param events The events.
+	 * @param pool The event pool.
+	 * @returns The event envelopes.
+	 */
 	abstract appendEvents(
 		eventStream: EventStream,
 		version: number,
 		events: IEvent[],
 		pool?: IEventPool,
 	): Promise<EventEnvelope[]>;
+
+	/**
+	 * Get envelopes from the event stream.
+	 * @param eventStream The event stream.
+	 * @param filter The event filter.
+	 * @returns The event envelopes.
+	 */
 	abstract getEnvelopes?(eventStream: EventStream, filter?: IEventFilter): AsyncGenerator<EventEnvelope[]>;
+
+	/**
+	 * Get an envelope from the event stream.
+	 * @param eventStream The event stream.
+	 * @param version The event version.
+	 * @param pool The event pool.
+	 * @returns The event envelope.
+	 */
 	abstract getEnvelope?(
 		eventStream: EventStream,
 		version: number,

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -27,67 +27,67 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	 */
 	public abstract disconnect(): void | Promise<void>;
 
-    /**
-     * Ensure the snapshot collection exists.
-     * @param pool The snapshot pool.
-     * @returns The snapshot collection.
-     */
+	/**
+	 * Ensure the snapshot collection exists.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot collection.
+	 */
 	public abstract ensureCollection(pool?: ISnapshotPool): ISnapshotCollection | Promise<ISnapshotCollection>;
 
-    /**
-     * Get snapshots from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param filter The snapshot filter
-     * @returns The snapshots.
-     */
+	/**
+	 * Get snapshots from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param filter The snapshot filter
+	 * @returns The snapshots.
+	 */
 	abstract getSnapshots<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		filter?: ISnapshotFilter,
 	): AsyncGenerator<ISnapshot<A>[]>;
 
-    /**
-     * Get a snapshot from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param version The snapshot version.
-     * @param pool The snapshot pool.
-     * @returns The snapshot.
-     */
+	/**
+	 * Get a snapshot from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param version The snapshot version.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot.
+	 */
 	abstract getSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
 
-    /**
-     * Get the last snapshot from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param pool The snapshot pool.
-     * @returns The snapshot.
-     */
+	/**
+	 * Get the last snapshot from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot.
+	 */
 	abstract getLastSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
 
-    /**
-     * Get the last snapshot from multiple snapshot streams.
-     * @param snapshotStreams The snapshot streams.
-     * @param pool The snapshot pool.
-     * @returns The snapshots.
-     */
+	/**
+	 * Get the last snapshot from multiple snapshot streams.
+	 * @param snapshotStreams The snapshot streams.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshots.
+	 */
 	abstract getManyLastSnapshots<A extends AggregateRoot>(
 		snapshotStreams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Map<SnapshotStream, ISnapshot<A>> | Promise<Map<SnapshotStream, ISnapshot<A>>>;
 
-    /**
-     * Append a snapshot to the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param version The snapshot version.
-     * @param snapshot The snapshot.
-     * @param pool The snapshot pool.
-     * @returns The snapshot envelope.
-     */
+	/**
+	 * Append a snapshot to the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param version The snapshot version.
+	 * @param snapshot The snapshot.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot envelope.
+	 */
 	abstract appendSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
@@ -95,47 +95,47 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
 
-    /**
-     * Get the last snapshot envelope from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param pool The snapshot pool.
-     * @returns The snapshot envelope.
-     */
+	/**
+	 * Get the last snapshot envelope from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot envelope.
+	 */
 	abstract getLastEnvelope<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
 
-    /**
-     * Get the last snapshot envelopes from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param filter The snapshot filter.
-     * @returns The snapshot envelopes.
-     */
+	/**
+	 * Get the last snapshot envelopes from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param filter The snapshot filter.
+	 * @returns The snapshot envelopes.
+	 */
 	abstract getEnvelopes?<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		filter?: ISnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;
 
-    /**
-     * Get a snapshot envelope from the snapshot stream.
-     * @param snapshotStream The snapshot stream.
-     * @param version The snapshot version.
-     * @param pool The snapshot pool.
-     * @returns The snapshot envelope.
-     */
+	/**
+	 * Get a snapshot envelope from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param version The snapshot version.
+	 * @param pool The snapshot pool.
+	 * @returns The snapshot envelope.
+	 */
 	abstract getEnvelope?<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
 
-    /**
-     * Get the last snapshot envelopes from the snapshot stream.
-     * @param aggregateName The aggregate name.
-     * @param filter The snapshot filter.
-     * @returns The snapshot envelopes.
-     */
+	/**
+	 * Get the last snapshot envelopes from the snapshot stream.
+	 * @param aggregateName The aggregate name.
+	 * @param filter The snapshot filter.
+	 * @returns The snapshot envelopes.
+	 */
 	abstract getLastEnvelopes?<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -17,47 +17,125 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 
 	constructor(protected readonly options: TOptions) {}
 
+	/**
+	 * Connect to the snapshot store
+	 */
 	public abstract connect(): void | Promise<void>;
+
+	/**
+	 * Disconnect from the snapshot store
+	 */
 	public abstract disconnect(): void | Promise<void>;
 
+    /**
+     * Ensure the snapshot collection exists.
+     * @param pool The snapshot pool.
+     * @returns The snapshot collection.
+     */
 	public abstract ensureCollection(pool?: ISnapshotPool): ISnapshotCollection | Promise<ISnapshotCollection>;
 
+    /**
+     * Get snapshots from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param filter The snapshot filter
+     * @returns The snapshots.
+     */
 	abstract getSnapshots<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		filter?: ISnapshotFilter,
 	): AsyncGenerator<ISnapshot<A>[]>;
+
+    /**
+     * Get a snapshot from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param version The snapshot version.
+     * @param pool The snapshot pool.
+     * @returns The snapshot.
+     */
 	abstract getSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
+
+    /**
+     * Get the last snapshot from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param pool The snapshot pool.
+     * @returns The snapshot.
+     */
 	abstract getLastSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
+
+    /**
+     * Get the last snapshot from multiple snapshot streams.
+     * @param snapshotStreams The snapshot streams.
+     * @param pool The snapshot pool.
+     * @returns The snapshots.
+     */
 	abstract getManyLastSnapshots<A extends AggregateRoot>(
 		snapshotStreams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Map<SnapshotStream, ISnapshot<A>> | Promise<Map<SnapshotStream, ISnapshot<A>>>;
+
+    /**
+     * Append a snapshot to the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param version The snapshot version.
+     * @param snapshot The snapshot.
+     * @param pool The snapshot pool.
+     * @returns The snapshot envelope.
+     */
 	abstract appendSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
 		snapshot: ISnapshot<A>,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
+
+    /**
+     * Get the last snapshot envelope from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param pool The snapshot pool.
+     * @returns The snapshot envelope.
+     */
 	abstract getLastEnvelope<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
+
+    /**
+     * Get the last snapshot envelopes from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param filter The snapshot filter.
+     * @returns The snapshot envelopes.
+     */
 	abstract getEnvelopes?<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		filter?: ISnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;
+
+    /**
+     * Get a snapshot envelope from the snapshot stream.
+     * @param snapshotStream The snapshot stream.
+     * @param version The snapshot version.
+     * @param pool The snapshot pool.
+     * @returns The snapshot envelope.
+     */
 	abstract getEnvelope?<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,
 		pool?: ISnapshotPool,
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
+
+    /**
+     * Get the last snapshot envelopes from the snapshot stream.
+     * @param aggregateName The aggregate name.
+     * @param filter The snapshot filter.
+     * @returns The snapshot envelopes.
+     */
 	abstract getLastEnvelopes?<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -35,6 +35,10 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
+	abstract getManyLastSnapshots<A extends AggregateRoot>(
+		snapshotStreams: SnapshotStream[],
+		pool?: ISnapshotPool,
+	): Map<SnapshotStream, ISnapshot<A>> | Promise<Map<SnapshotStream, ISnapshot<A>>>;
 	abstract appendSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		version: number,

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -174,6 +174,14 @@ describe(InMemorySnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
+	it('should retrieve multiple last snapshots', () => {
+		const resolvedSnapshots = snapshotStore.getManyLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+		expect(resolvedSnapshots.get(snapshotStreamAccountB)).toEqual(snapshotsAccountB[snapshotsAccountB.length - 1]);
+	});
+
 	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {

--- a/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
@@ -217,6 +217,17 @@ describe(DynamoDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
+	it('should retrieve multiple last snapshots', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+		expect(resolvedSnapshots.get(snapshotStreamAccountB)).toEqual(snapshotsAccountB[snapshotsAccountB.length - 1]);
+	});
+
 	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -188,8 +188,11 @@ describe(MariaDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
-    it('should retrieve multiple last snapshots', async () => {
-		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
+	it('should retrieve multiple last snapshots', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -188,6 +188,14 @@ describe(MariaDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
+    it('should retrieve multiple last snapshots', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+		expect(resolvedSnapshots.get(snapshotStreamAccountB)).toEqual(snapshotsAccountB[snapshotsAccountB.length - 1]);
+	});
+
 	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -182,6 +182,17 @@ describe(MongoDBSnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
+	it('should retrieve multiple last snapshots', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+		expect(resolvedSnapshots.get(snapshotStreamAccountB)).toEqual(snapshotsAccountB[snapshotsAccountB.length - 1]);
+	});
+
 	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -193,6 +193,17 @@ describe(PostgresSnapshotStore, () => {
 		expect(resolvedSnapshot).toBeUndefined();
 	});
 
+	it('should retrieve multiple last snapshots', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);
+		expect(resolvedSnapshots.get(snapshotStreamAccountB)).toEqual(snapshotsAccountB[snapshotsAccountB.length - 1]);
+	});
+
 	it('should retrieve snapshot-envelopes', async () => {
 		const resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getEnvelopes(snapshotStreamAccountA)) {


### PR DESCRIPTION
- **:sparkles: add a method to get the last snapshots from specified snapshot-streams**
- **✅ add tests for the snapshot-store integrations to retrieve multiple last snapshots**
- **✨ refactor the getLastStreamEntity method to return multiple and add a getManyLastSnapshots method**
- **💡 add jsdocs to the event- and snapshot-store**

# Description

Adds a getManyLastSnapshots function to all snapshot-stores in order to easily retrieve the latest snapshots for multiple streams.

Fixes #302

## Type of change

_Please delete options that are not relevant._

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

