### PR TITLE
[304] Implement a getManyLastSnapshotEnvelopes method

### DIFF
--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -235,7 +235,7 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 		});
 	}
 
-	async *getLastEnvelopes<A extends AggregateRoot>(
+	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -272,6 +272,23 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 		}
 	}
 
+	getManyLastSnapshotEnvelopes<A extends AggregateRoot>(
+		streams: SnapshotStream[],
+		pool?: ISnapshotPool,
+	): Map<SnapshotStream, SnapshotEnvelope<A>> {
+		const collection = SnapshotCollection.get(pool);
+		const snapshotCollection = this.collections.get(collection) || [];
+
+		const entities = this.getLastStreamEntities<A>(snapshotCollection, streams);
+
+		return new Map(
+			entities.map(({ streamId, payload, aggregateId, registeredOn, snapshotId, version }) => [
+				streams.find(({ streamId: currentStreamId }) => currentStreamId === streamId),
+				SnapshotEnvelope.from<A>(payload, { aggregateId, registeredOn, snapshotId, version }),
+			]),
+		);
+	}
+
 	private getLastStreamEntities<A extends AggregateRoot>(
 		collection: InMemorySnapshotEntity<any>[],
 		streams: SnapshotStream[],

--- a/packages/core/lib/snapshot-handler.ts
+++ b/packages/core/lib/snapshot-handler.ts
@@ -53,7 +53,7 @@ export abstract class SnapshotHandler<A extends AggregateRoot = AggregateRoot> i
 	}
 	async *loadMany(filter?: { fromId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		const id = filter?.fromId?.value;
-		for await (const envelopes of this.snapshotStore.getLastEnvelopes<A>(this.streamName, {
+		for await (const envelopes of this.snapshotStore.getLastAggregateEnvelopes<A>(this.streamName, {
 			...filter,
 			fromId: id,
 		})) {

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -131,12 +131,12 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
 
 	/**
-	 * Get the last snapshot envelopes from the snapshot stream.
+	 * Get the last snapshot envelopes for a specified aggregate.
 	 * @param aggregateName The aggregate name.
 	 * @param filter The snapshot filter.
 	 * @returns The snapshot envelopes.
 	 */
-	abstract getLastEnvelopes?<A extends AggregateRoot>(
+	abstract getLastAggregateEnvelopes?<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -140,4 +140,15 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;
+
+	/**
+	 * Get the last snapshot envelopes from multiple snapshot streams.
+	 * @param snapshotStreams The snapshot streams
+	 * @param pool The snapshot pool
+	 * @returns The snapshot envelopes
+	 */
+	abstract getManyLastSnapshotEnvelopes?<A extends AggregateRoot>(
+		snapshotStreams: SnapshotStream[],
+		pool?: ISnapshotPool,
+	): Map<SnapshotStream, SnapshotEnvelope<A>> | Promise<Map<SnapshotStream, SnapshotEnvelope<A>>>;
 }

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'node:crypto';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -220,7 +221,49 @@ describe(InMemorySnapshotStore, () => {
 		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelopes', async () => {
+	it('should filter the last snapshot-envelopes by streamId', async () => {
+		@Aggregate({ streamName: 'foo' })
+		class Foo extends AggregateRoot {}
+
+		class FooId extends UUID {}
+
+		const fooIds = Array.from({ length: 20 })
+			.map(() => FooId.generate())
+			.sort();
+		for await (const id of fooIds) {
+			await snapshotStore.appendSnapshot(SnapshotStream.for(Foo, id), randomInt(1, 10) * 10, {
+				balance: randomInt(1000),
+			});
+		}
+
+		const fetchedAccountIds: Set<string> = new Set();
+		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+			firstPageEnvelopes.push(...envelopes);
+		}
+
+		expect(firstPageEnvelopes).toHaveLength(15);
+		for (const { metadata } of firstPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+			limit: 5,
+			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+		})) {
+			lastPageEnvelopes.push(...envelopes);
+		}
+
+		expect(lastPageEnvelopes).toHaveLength(5);
+		for (const { metadata } of lastPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		expect(fooIds).toHaveLength(20);
+	});
+
+	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
@@ -244,5 +287,32 @@ describe(InMemorySnapshotStore, () => {
 		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
 		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
 		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
+	});
+
+	it('should retrieve multiple last snapshot-envelopes for given streams', () => {
+		const resolvedSnapshots = snapshotStore.getManyLastSnapshotEnvelopes([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+
+		const [envelopeAccountA, envelopeAccountB] = [
+			envelopesAccountA[envelopesAccountA.length - 1],
+			envelopesAccountB[envelopesAccountB.length - 1],
+		];
+
+		const resolvedAccountAEnvelope = resolvedSnapshots.get(snapshotStreamAccountA);
+		const resolvedAccountBEnvelope = resolvedSnapshots.get(snapshotStreamAccountB);
+
+		expect(resolvedAccountAEnvelope.payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedAccountAEnvelope.metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedAccountAEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountAEnvelope.metadata.version).toEqual(envelopeAccountA.metadata.version);
+
+		expect(resolvedAccountBEnvelope.payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedAccountBEnvelope.metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedAccountBEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountBEnvelope.metadata.version).toEqual(envelopeAccountB.metadata.version);
 	});
 });

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -222,7 +222,7 @@ describe(InMemorySnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 

--- a/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
+++ b/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
@@ -387,7 +387,7 @@ export class DynamoDBSnapshotStore extends SnapshotStore<DynamoDBSnapshotStoreCo
 		});
 	}
 
-	async *getLastEnvelopes<A extends AggregateRoot>(
+	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {

--- a/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
@@ -268,7 +268,7 @@ describe(DynamoDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -309,7 +309,7 @@ describe(DynamoDBSnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -319,7 +319,7 @@ describe(DynamoDBSnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {

--- a/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
@@ -290,7 +290,7 @@ export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConf
 		});
 	}
 
-	async *getLastEnvelopes<A extends AggregateRoot>(
+	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'node:crypto';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -233,7 +234,7 @@ describe(MariaDBSnapshotStore, () => {
 		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelopes', async () => {
+	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
@@ -252,5 +253,74 @@ describe(MariaDBSnapshotStore, () => {
 		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
 		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
 		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
+	});
+
+	it('should filter the last snapshot-envelopes by streamId', async () => {
+		@Aggregate({ streamName: 'foo' })
+		class Foo extends AggregateRoot {}
+
+		class FooId extends UUID {}
+
+		const fooIds = Array.from({ length: 20 })
+			.map(() => FooId.generate())
+			.sort();
+		for await (const id of fooIds) {
+			await snapshotStore.appendSnapshot(SnapshotStream.for(Foo, id), randomInt(1, 10) * 10, {
+				balance: randomInt(1000),
+			});
+		}
+
+		const fetchedAccountIds: Set<string> = new Set();
+		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+			firstPageEnvelopes.push(...envelopes);
+		}
+
+		expect(firstPageEnvelopes).toHaveLength(15);
+		for (const { metadata } of firstPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+			limit: 5,
+			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+		})) {
+			lastPageEnvelopes.push(...envelopes);
+		}
+
+		expect(lastPageEnvelopes).toHaveLength(5);
+		for (const { metadata } of lastPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		expect(fooIds).toHaveLength(20);
+	});
+
+	it('should retrieve multiple last snapshot-envelopes for given streams', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshotEnvelopes([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+
+		const [envelopeAccountA, envelopeAccountB] = [
+			envelopesAccountA[envelopesAccountA.length - 1],
+			envelopesAccountB[envelopesAccountB.length - 1],
+		];
+
+		const resolvedAccountAEnvelope = resolvedSnapshots.get(snapshotStreamAccountA);
+		const resolvedAccountBEnvelope = resolvedSnapshots.get(snapshotStreamAccountB);
+
+		expect(resolvedAccountAEnvelope.payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedAccountAEnvelope.metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedAccountAEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountAEnvelope.metadata.version).toEqual(envelopeAccountA.metadata.version);
+
+		expect(resolvedAccountBEnvelope.payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedAccountBEnvelope.metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedAccountBEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountBEnvelope.metadata.version).toEqual(envelopeAccountB.metadata.version);
 	});
 });

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -235,7 +235,7 @@ describe(MariaDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 		expect(resolvedEnvelopes).toHaveLength(2);

--- a/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
@@ -267,7 +267,7 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 		});
 	}
 
-	async *getLastEnvelopes<A extends AggregateRoot>(
+	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'node:crypto';
 import {
 	Aggregate,
 	AggregateRoot,
@@ -218,33 +219,98 @@ describe(MongoDBSnapshotStore, () => {
 		expect(metadata.version).toEqual(envelopesAccountA[3].metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelope', async () => {
-		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = await snapshotStore.getLastEnvelope(snapshotStreamAccountA);
-		expect(payload).toEqual(lastEnvelope.payload);
-		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);
-		expect(metadata.registeredOn).toBeInstanceOf(Date);
-		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
-	});
-
-	it('should retrieve the last snapshot-envelopes', async () => {
+	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
+
 		expect(resolvedEnvelopes).toHaveLength(2);
+
 		const [envelopeAccountB, envelopeAccountA] = [
 			envelopesAccountB[envelopesAccountB.length - 1],
 			envelopesAccountA[envelopesAccountA.length - 1],
 		];
+
 		resolvedEnvelopes = resolvedEnvelopes.sort((a, b) => (a.metadata.version > b.metadata.version ? 1 : -1));
+
 		expect(resolvedEnvelopes[0].payload).toEqual(envelopeAccountB.payload);
 		expect(resolvedEnvelopes[0].metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
 		expect(resolvedEnvelopes[0].metadata.registeredOn).toBeInstanceOf(Date);
 		expect(resolvedEnvelopes[0].metadata.version).toEqual(envelopeAccountB.metadata.version);
+
 		expect(resolvedEnvelopes[1].payload).toEqual(envelopeAccountA.payload);
 		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
 		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
 		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
+	});
+
+	it('should filter the last snapshot-envelopes by streamId', async () => {
+		@Aggregate({ streamName: 'foo' })
+		class Foo extends AggregateRoot {}
+
+		class FooId extends UUID {}
+
+		const fooIds = Array.from({ length: 20 })
+			.map(() => FooId.generate())
+			.sort();
+		for await (const id of fooIds) {
+			await snapshotStore.appendSnapshot(SnapshotStream.for(Foo, id), randomInt(1, 10) * 10, {
+				balance: randomInt(1000),
+			});
+		}
+
+		const fetchedAccountIds: Set<string> = new Set();
+		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+			firstPageEnvelopes.push(...envelopes);
+		}
+
+		expect(firstPageEnvelopes).toHaveLength(15);
+		for (const { metadata } of firstPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+			limit: 5,
+			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+		})) {
+			lastPageEnvelopes.push(...envelopes);
+		}
+
+		expect(lastPageEnvelopes).toHaveLength(5);
+		for (const { metadata } of lastPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		expect(fooIds).toHaveLength(20);
+	});
+
+	it('should retrieve multiple last snapshot-envelopes for given streams', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshotEnvelopes([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+
+		const [envelopeAccountA, envelopeAccountB] = [
+			envelopesAccountA[envelopesAccountA.length - 1],
+			envelopesAccountB[envelopesAccountB.length - 1],
+		];
+
+		const resolvedAccountAEnvelope = resolvedSnapshots.get(snapshotStreamAccountA);
+		const resolvedAccountBEnvelope = resolvedSnapshots.get(snapshotStreamAccountB);
+
+		expect(resolvedAccountAEnvelope.payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedAccountAEnvelope.metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedAccountAEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountAEnvelope.metadata.version).toEqual(envelopeAccountA.metadata.version);
+
+		expect(resolvedAccountBEnvelope.payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedAccountBEnvelope.metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedAccountBEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountBEnvelope.metadata.version).toEqual(envelopeAccountB.metadata.version);
 	});
 });

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -229,7 +229,7 @@ describe(MongoDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 		expect(resolvedEnvelopes).toHaveLength(2);

--- a/packages/integration/postgres/lib/postgres.snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres.snapshot-store.ts
@@ -355,6 +355,27 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 		cursor.close(() => {});
 	}
 
+	async getManyLastSnapshotEnvelopes<A extends AggregateRoot>(
+		streams: SnapshotStream[],
+		pool?: ISnapshotPool,
+	): Promise<Map<SnapshotStream, SnapshotEnvelope<A>>> {
+		const collection = SnapshotCollection.get(pool);
+
+		const entities = await this.getLastStreamEntities<A>(collection, streams);
+
+		return new Map(
+			entities.map(({ stream_id, payload, aggregate_id, registered_on, snapshot_id, version }) => [
+				streams.find(({ streamId: currentStreamId }) => currentStreamId === stream_id),
+				SnapshotEnvelope.from<A>(payload, {
+					aggregateId: aggregate_id,
+					registeredOn: new Date(registered_on),
+					snapshotId: snapshot_id,
+					version,
+				}),
+			]),
+		);
+	}
+
 	private async getLastStreamEntities<A extends AggregateRoot>(
 		collection: string,
 		streams: SnapshotStream[],

--- a/packages/integration/postgres/lib/postgres.snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres.snapshot-store.ts
@@ -306,7 +306,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 		});
 	}
 
-	async *getLastEnvelopes<A extends AggregateRoot>(
+	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
 		aggregateName: string,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -240,7 +240,7 @@ describe(PostgresSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 		expect(resolvedEnvelopes).toHaveLength(2);

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'node:crypto';
 import {} from '@nestjs/core';
 import {
 	Aggregate,
@@ -238,7 +239,7 @@ describe(PostgresSnapshotStore, () => {
 		expect(metadata.version).toEqual(lastEnvelope.metadata.version);
 	});
 
-	it('should retrieve the last snapshot-envelopes', async () => {
+	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
 			resolvedEnvelopes.push(...envelopes);
@@ -257,5 +258,74 @@ describe(PostgresSnapshotStore, () => {
 		expect(resolvedEnvelopes[1].metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
 		expect(resolvedEnvelopes[1].metadata.registeredOn).toBeInstanceOf(Date);
 		expect(resolvedEnvelopes[1].metadata.version).toEqual(envelopeAccountA.metadata.version);
+	});
+
+	it('should filter the last snapshot-envelopes by streamId', async () => {
+		@Aggregate({ streamName: 'foo' })
+		class Foo extends AggregateRoot {}
+
+		class FooId extends UUID {}
+
+		const fooIds = Array.from({ length: 20 })
+			.map(() => FooId.generate())
+			.sort();
+		for await (const id of fooIds) {
+			await snapshotStore.appendSnapshot(SnapshotStream.for(Foo, id), randomInt(1, 10) * 10, {
+				balance: randomInt(1000),
+			});
+		}
+
+		const fetchedAccountIds: Set<string> = new Set();
+		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+			firstPageEnvelopes.push(...envelopes);
+		}
+
+		expect(firstPageEnvelopes).toHaveLength(15);
+		for (const { metadata } of firstPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
+		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+			limit: 5,
+			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+		})) {
+			lastPageEnvelopes.push(...envelopes);
+		}
+
+		expect(lastPageEnvelopes).toHaveLength(5);
+		for (const { metadata } of lastPageEnvelopes) {
+			fetchedAccountIds.add(metadata.aggregateId);
+		}
+
+		expect(fooIds).toHaveLength(20);
+	});
+
+	it('should retrieve multiple last snapshot-envelopes for given streams', async () => {
+		const resolvedSnapshots = await snapshotStore.getManyLastSnapshotEnvelopes([
+			snapshotStreamAccountA,
+			snapshotStreamAccountB,
+		]);
+
+		expect(resolvedSnapshots.size).toBe(2);
+
+		const [envelopeAccountA, envelopeAccountB] = [
+			envelopesAccountA[envelopesAccountA.length - 1],
+			envelopesAccountB[envelopesAccountB.length - 1],
+		];
+
+		const resolvedAccountAEnvelope = resolvedSnapshots.get(snapshotStreamAccountA);
+		const resolvedAccountBEnvelope = resolvedSnapshots.get(snapshotStreamAccountB);
+
+		expect(resolvedAccountAEnvelope.payload).toEqual(envelopeAccountA.payload);
+		expect(resolvedAccountAEnvelope.metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);
+		expect(resolvedAccountAEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountAEnvelope.metadata.version).toEqual(envelopeAccountA.metadata.version);
+
+		expect(resolvedAccountBEnvelope.payload).toEqual(envelopeAccountB.payload);
+		expect(resolvedAccountBEnvelope.metadata.aggregateId).toEqual(envelopeAccountB.metadata.aggregateId);
+		expect(resolvedAccountBEnvelope.metadata.registeredOn).toBeInstanceOf(Date);
+		expect(resolvedAccountBEnvelope.metadata.version).toEqual(envelopeAccountB.metadata.version);
 	});
 });


### PR DESCRIPTION
- **:recycle: rename getLastEnvelopes to getlastAggregateEnvelopes**
- **✨ add a method to get the last snapshot envelopes from specified snapshot-streams**
- **✅ add tests for the snapshot-store integrations to retrieve multiple last snapshot envelopes by streams**
- **✨ implement getManyLastSnapshotEnvelopes for the integrations**

# Description

This PR adds a getManyLastSnapshotEnvelopes method to retrieve last snapshot envelopes for the provided streams

Fixes #304

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


