### PR TITLE
[318] Refactor pipelines

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+docs:
+  - changed-files:
+      - any-glob-to-any-file: ["docs/*", "example/*", "**/*.md"]
+
+packages:
+  - changed-files:
+      - any-glob-to-any-file: "packages/*"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ["**/package.json", "pnpm-lock.yaml"]
+
+workflows:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"

--- a/.github/setup-job-env.yml
+++ b/.github/setup-job-env.yml
@@ -1,0 +1,36 @@
+name: Setup job environment
+description: "Retrieve the turbo cache, install pnpm, setup Node.js, and install dependencies"
+
+inputs:
+  cache-key:
+    description: "Input to the reusable workflow"
+    required: true
+    type: string
+  node-version:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache turbo build setup
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ inputs.cache-key }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-key }}-turbo-
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9.10.0
+
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           static_site_generator: next
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Build
         run: pnpm build --filter='./docs/**'
 

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -22,26 +22,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v4
+      - name: Setup job
+        id: setup-job
+        uses: ./.github/setup-job
         with:
-          path: .turbo
-          key: docs-turbo-${{ github.sha }}
-          restore-keys: |
-            docs-turbo-
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.10.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
+          cache-key: docs
           node-version: 22.x
-          cache: "pnpm"
 
       - name: Setup GH Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup job
         id: setup-job
-        uses: ./.github/setup-job
+        uses: ./.github/setup-job-env
         with:
           cache-key: docs
           node-version: 22.x

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,15 @@
+name: CI Docs
+
+on:
+    workflow_dispatch:
+    pull_request:
+      branches: ['master']
+      paths:
+        - .github/ci-docs.yml
+        - docs/**
+
+jobs:
+  merge-check:
+    uses: ./.github/workflows/merge-check.yml
+    with:
+      conditions: true

--- a/.github/workflows/ci-libraries.yml
+++ b/.github/workflows/ci-libraries.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ['master']
+    paths:
+      - .github/ci-libraries.yml
+      - packages/**
+      - package.json
+      - pnpm-*.yaml
+      - turbo.json
 
 jobs:
   build:

--- a/.github/workflows/ci-libraries.yml
+++ b/.github/workflows/ci-libraries.yml
@@ -89,3 +89,9 @@ jobs:
 
       - name: Test
         run: pnpm test --filter=@ocoda/event-sourcing-${{ matrix.database }}
+
+  merge-check:
+    needs: [build, test-core-lib, test-integration-libs]
+    uses: ./.github/workflows/merge-check.yml
+    with:
+        conditions: ${{ needs.build.result }} && ${{ needs.test-core-lib.result }} && ${{ needs.test-integration-libs.result }}

--- a/.github/workflows/ci-libraries.yml
+++ b/.github/workflows/ci-libraries.yml
@@ -18,29 +18,15 @@ jobs:
     name: Validate build [Node.js ${{ matrix.node-version }}]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v4
+      - name: Setup job environment
+        id: setup-job
+        uses: ./.github/setup-job-env
         with:
-          path: .turbo
-          key: node-${{ matrix.node-version }}-turbo-${{ github.sha }}
-          restore-keys: |
-            node-${{ matrix.node-version }}-turbo-
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.10.0
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
+          cache-key: node-${{ matrix.node-version }}
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build --filter="./packages/**"
@@ -54,29 +40,15 @@ jobs:
     name: Test core lib [Node.js ${{ matrix.node-version }}]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
-      - name: Cache turbo test setup
-        uses: actions/cache@v4
+      - name: Setup job environment
+        id: setup-job
+        uses: ./.github/setup-job-env
         with:
-          path: .turbo
-          key: node-${{ matrix.node-version }}-turbo-${{ github.sha }}
-          restore-keys: |
-            node-${{ matrix.node-version }}-turbo-
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.10.0
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
+          cache-key: node-${{ matrix.node-version }}
           node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Test linting, formatting and import sorting
         run: pnpm run ci --filter=@ocoda/event-sourcing
@@ -95,32 +67,18 @@ jobs:
     name: Test ${{ matrix.database }} lib [Node.js ${{ matrix.node-version }}]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
       - name: Start database
         run: docker compose up -d ${{ matrix.database }}
 
-      - name: Cache turbo test setup
-        uses: actions/cache@v4
+      - name: Setup job environment
+        id: setup-job
+        uses: ./.github/setup-job-env
         with:
-          path: .turbo
-          key: node-${{ matrix.node-version }}-turbo-${{ github.sha }}
-          restore-keys: |
-            node-${{ matrix.node-version }}-turbo-
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.10.0
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
+          cache-key: node-${{ matrix.node-version }}
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Test linting, formatting and import sorting
         run: pnpm run ci --filter=@ocoda/event-sourcing-${{ matrix.database }}

--- a/.github/workflows/ci-libraries.yml
+++ b/.github/workflows/ci-libraries.yml
@@ -2,8 +2,6 @@ name: CI Libraries
 
 on:
   workflow_dispatch:
-  push:
-    branches: ['master']
   pull_request:
     branches: ['master']
 

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,0 +1,26 @@
+name: PR merge check
+
+on:
+  workflow_call:
+    inputs:
+      conditions:
+        description: "Conditions to merge the PR"
+        required: true
+        type: boolean
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  results:
+    name: Merge check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ ${{ inputs.conditions }} ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,15 @@
+name: PR Labeler
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true
+        dot: true


### PR DESCRIPTION
- **👷 extract the setup steps into a reusable steps file**
- **👷 don't run the ci-libraries workflow when merging in master**
- **👷 label PR's**
- **👷 conditionally run the ci-libraries workflow**
- **👷 remove the pnpm install step**
- **👷 fix the shared steps in the cd-docs workflow**
- **👷 add a job that reports if a PR workflow is mergeable**

# Description

- extracts reusable snippets in shared workflows and composite steps
- run ci pipelines only for the paths that they cover
- introduce a single merge-check to protect the master branch

Fixes #318

