### PR TITLE
[370] Add a getAllEnvelopes method to the event-stores

### DIFF
--- a/.changeset/smooth-pots-brush.md
+++ b/.changeset/smooth-pots-brush.md
@@ -1,0 +1,9 @@
+---
+"@ocoda/event-sourcing-dynamodb": minor
+"@ocoda/event-sourcing-postgres": minor
+"@ocoda/event-sourcing-mariadb": minor
+"@ocoda/event-sourcing-mongodb": minor
+"@ocoda/event-sourcing": minor
+---
+
+Support for a getAllEnvelopes method on the EventStore

--- a/docs/pages/start/snapshots.mdx
+++ b/docs/pages/start/snapshots.mdx
@@ -16,7 +16,7 @@ The base class provides the following methods:
 - `save(id: Id, aggregate: A, pool?: ISnapshotPool): Promise<void>`: Saves a snapshot of the aggregate.
 - `load(id: Id, pool?: ISnapshotPool): Promise<A>`: Loads the latest snapshot of the aggregate or returns a blank aggregate.
 - `loadMany(ids: Id[], pool?: ISnapshotPool): Promise<A[]>`: Loads the latest snapshots of multiple aggregates.
-- `*loadAll(filter?: { fromId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]>`: Search all latest snapshots from the store. Returns an async iterator.
+- `*loadAll(filter?: { aggregateId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]>`: Search all latest snapshots from the store. Returns an async iterator.
 
 The two methods you will need to implement are **`serialize`** and **`deserialize`**.
 

--- a/example/src/application/repositories/account.repository.ts
+++ b/example/src/application/repositories/account.repository.ts
@@ -41,10 +41,10 @@ export class AccountRepository {
 		return accounts;
 	}
 
-	async getAll(fromAccountId?: AccountId, limit?: number): Promise<Account[]> {
+	async getAll(accountId?: AccountId, limit?: number): Promise<Account[]> {
 		const accounts = [];
 		for await (const envelopes of this.accountSnapshotRepository.loadAll({
-			fromId: fromAccountId,
+			aggregateId: accountId,
 			limit,
 		})) {
 			for (const { metadata, payload } of envelopes) {

--- a/packages/core/lib/event-store.ts
+++ b/packages/core/lib/event-store.ts
@@ -71,14 +71,6 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 	public abstract listCollections(filter?: IEventCollectionFilter): AsyncGenerator<IEventCollection[]>;
 
 	/**
-	 * Get events from the event stream.
-	 * @param eventStream The event stream.
-	 * @param filter The event filter.
-	 * @returns The events.
-	 */
-	abstract getEvents(eventStream: EventStream, filter?: IEventFilter): AsyncGenerator<IEvent[]>;
-
-	/**
 	 * Get an event from the event stream.
 	 * @param eventStream The event stream.
 	 * @param version The event version.
@@ -86,6 +78,14 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 	 * @returns The event.
 	 */
 	abstract getEvent(eventStream: EventStream, version: number, pool?: IEventPool): IEvent | Promise<IEvent>;
+
+	/**
+	 * Get events from the event stream.
+	 * @param eventStream The event stream.
+	 * @param filter The event filter.
+	 * @returns The events.
+	 */
+	abstract getEvents(eventStream: EventStream, filter?: IEventFilter): AsyncGenerator<IEvent[]>;
 
 	/**
 	 * Append events to the event stream.

--- a/packages/core/lib/event-store.ts
+++ b/packages/core/lib/event-store.ts
@@ -4,6 +4,7 @@ import { EventMap } from './event-map';
 import type {
 	EventSourcingModuleOptions,
 	EventStoreDriver,
+	IAllEventsFilter,
 	IEvent,
 	IEventCollection,
 	IEventCollectionFilter,
@@ -122,4 +123,10 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 		version: number,
 		pool?: IEventPool,
 	): EventEnvelope | Promise<EventEnvelope>;
+
+	/**
+	 * Get all envelopes from the event store.
+	 * @description creates a range of YYYY-MM from since to until and gets all events in that range
+	 */
+	abstract getAllEnvelopes(filter: IAllEventsFilter): AsyncGenerator<EventEnvelope[]>;
 }

--- a/packages/core/lib/event-store.ts
+++ b/packages/core/lib/event-store.ts
@@ -129,4 +129,31 @@ export abstract class EventStore<TOptions = Omit<EventSourcingModuleOptions['eve
 	 * @description creates a range of YYYY-MM from since to until and gets all events in that range
 	 */
 	abstract getAllEnvelopes(filter: IAllEventsFilter): AsyncGenerator<EventEnvelope[]>;
+
+	protected getYearMonthRange(
+		sinceDate: { year: number; month: number },
+		untilDate?: { year: number; month: number },
+	): string[] {
+		const now = new Date();
+		const [untilYear, untilMonth] = untilDate
+			? [untilDate.year, untilDate.month]
+			: [now.getFullYear(), now.getMonth() + 1];
+		const since = Date.UTC(sinceDate.year, sinceDate.month - 1, 1, 0, 0, 0, 0);
+		const until = Date.UTC(untilYear, untilMonth, 0, 23, 59, 59, 999);
+
+		const yearMonthArray: string[] = [];
+		const currentDate = new Date(since);
+
+		// Continue looping until we pass the 'until' date
+		while (currentDate.getTime() <= until) {
+			const year = currentDate.getUTCFullYear();
+			const month = String(currentDate.getUTCMonth() + 1).padStart(2, '0'); // Convert month to 'MM' format
+			yearMonthArray.push(`${year}-${month}`);
+
+			// Move to the next month
+			currentDate.setUTCMonth(currentDate.getUTCMonth() + 1);
+		}
+
+		return yearMonthArray;
+	}
 }

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -1,4 +1,5 @@
 import type { Type } from '@nestjs/common';
+import { getAggregateMetadata } from '@ocoda/event-sourcing/helpers';
 import { DEFAULT_BATCH_SIZE, StreamReadingDirection } from '../../constants';
 import {
 	SnapshotNotFoundException,
@@ -273,11 +274,12 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 		});
 	}
 
-	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
-		aggregateName: string,
+	async *getLastEnvelopesForAggregate<A extends AggregateRoot>(
+		aggregate: Type<A>,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		let entities: InMemorySnapshotEntity<any>[] = [];
+		const { streamName: aggregateName } = getAggregateMetadata(aggregate);
 
 		const collection = SnapshotCollection.get(filter?.pool);
 		const fromId = filter?.fromId;

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -282,7 +282,7 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 		const { streamName: aggregateName } = getAggregateMetadata(aggregate);
 
 		const collection = SnapshotCollection.get(filter?.pool);
-		const fromId = filter?.fromId;
+		const aggregateId = filter?.aggregateId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
@@ -296,8 +296,8 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 			})
 			.reverse();
 
-		if (fromId) {
-			entities = this.collections.get(collection).filter(({ latest }) => latest > fromId);
+		if (aggregateId) {
+			entities = this.collections.get(collection).filter(({ latest }) => latest > aggregateId);
 		}
 
 		if (limit) {

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -1,5 +1,4 @@
 import type { Type } from '@nestjs/common';
-import { getAggregateMetadata } from '@ocoda/event-sourcing/helpers';
 import { DEFAULT_BATCH_SIZE, StreamReadingDirection } from '../../constants';
 import {
 	SnapshotNotFoundException,
@@ -7,6 +6,7 @@ import {
 	SnapshotStorePersistenceException,
 	SnapshotStoreVersionConflictException,
 } from '../../exceptions';
+import { getAggregateMetadata } from '../../helpers';
 import type {
 	ILatestSnapshotFilter,
 	ISnapshot,

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -182,7 +182,7 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 		}
 	}
 
-	getManyLastSnapshots<A extends AggregateRoot>(
+	getLastSnapshots<A extends AggregateRoot>(
 		streams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Map<SnapshotStream, ISnapshot<A>> {

--- a/packages/core/lib/interfaces/aggregate/latest-snapshot-filter.interface.ts
+++ b/packages/core/lib/interfaces/aggregate/latest-snapshot-filter.interface.ts
@@ -1,5 +1,5 @@
 import type { ISnapshotFilter } from './snapshot-filter.interface';
 
 export interface ILatestSnapshotFilter extends Pick<ISnapshotFilter, 'batch' | 'limit' | 'pool'> {
-	fromId?: string;
+	aggregateId?: string;
 }

--- a/packages/core/lib/interfaces/events/event-filter.interface.ts
+++ b/packages/core/lib/interfaces/events/event-filter.interface.ts
@@ -28,6 +28,19 @@ export interface IEventFilter {
 	batch?: number;
 }
 
+export interface IAllEventsFilter extends Pick<IEventFilter, 'pool' | 'batch'> {
+	/**
+	 * The year and month from where the events should be read.
+	 */
+	since: { year: number; month: number };
+
+	/**
+	 * The year and month up until where the events should be read.
+	 * @default now
+	 */
+	until?: { year: number; month: number };
+}
+
 export interface IEventCollectionFilter {
 	/**
 	 * The amount of collections to read at a time

--- a/packages/core/lib/models/ulid.ts
+++ b/packages/core/lib/models/ulid.ts
@@ -37,6 +37,10 @@ export class ULID extends Id {
 		return new Date(this.time);
 	}
 
+	get yearMonth(): string {
+		return this.date.toISOString().substring(0, 7);
+	}
+
 	static factory(): (dateSeed?: Date) => ULID {
 		const generator = monotonicFactory();
 		return (dateSeed?: Date) => new ULID(generator(dateSeed?.getTime()));

--- a/packages/core/lib/snapshot-repository.ts
+++ b/packages/core/lib/snapshot-repository.ts
@@ -63,11 +63,11 @@ export abstract class SnapshotRepository<A extends AggregateRoot = AggregateRoot
 		return aggregates;
 	}
 
-	async *loadAll(filter?: { fromId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]> {
-		const id = filter?.fromId?.value;
+	async *loadAll(filter?: { aggregateId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]> {
+		const id = filter?.aggregateId?.value;
 		for await (const envelopes of this.snapshotStore.getLastEnvelopesForAggregate<A>(this.aggregate, {
 			...filter,
-			fromId: id,
+			aggregateId: id,
 		})) {
 			yield envelopes;
 		}

--- a/packages/core/lib/snapshot-repository.ts
+++ b/packages/core/lib/snapshot-repository.ts
@@ -8,7 +8,6 @@ import { SnapshotStore } from './snapshot-store';
 
 export abstract class SnapshotRepository<A extends AggregateRoot = AggregateRoot> implements ISnapshotRepository<A> {
 	private readonly aggregate: Type<A>;
-	private readonly streamName: string;
 	private readonly interval: number;
 
 	constructor(@Inject(SnapshotStore) readonly snapshotStore: SnapshotStore) {
@@ -26,7 +25,6 @@ export abstract class SnapshotRepository<A extends AggregateRoot = AggregateRoot
 
 		this.aggregate = aggregate;
 		this.interval = interval;
-		this.streamName = streamName;
 	}
 
 	async save(id: Id, aggregate: A, pool?: ISnapshotPool): Promise<void> {
@@ -67,7 +65,7 @@ export abstract class SnapshotRepository<A extends AggregateRoot = AggregateRoot
 
 	async *loadAll(filter?: { fromId?: Id; limit?: number; pool?: string }): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		const id = filter?.fromId?.value;
-		for await (const envelopes of this.snapshotStore.getLastAggregateEnvelopes<A>(this.streamName, {
+		for await (const envelopes of this.snapshotStore.getLastEnvelopesForAggregate<A>(this.aggregate, {
 			...filter,
 			fromId: id,
 		})) {

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -82,7 +82,7 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	 * @param pool The snapshot pool.
 	 * @returns The snapshots.
 	 */
-	abstract getManyLastSnapshots<A extends AggregateRoot>(
+	abstract getLastSnapshots<A extends AggregateRoot>(
 		snapshotStreams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Map<SnapshotStream, ISnapshot<A>> | Promise<Map<SnapshotStream, ISnapshot<A>>>;

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Logger, type Type } from '@nestjs/common';
 import type {
 	EventSourcingModuleOptions,
 	ILatestSnapshotFilter,
@@ -42,17 +42,6 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	public abstract listCollections(filter?: ISnapshotCollectionFilter): AsyncGenerator<ISnapshotCollection[]>;
 
 	/**
-	 * Get snapshots from the snapshot stream.
-	 * @param snapshotStream The snapshot stream.
-	 * @param filter The snapshot filter
-	 * @returns The snapshots.
-	 */
-	abstract getSnapshots<A extends AggregateRoot>(
-		snapshotStream: SnapshotStream,
-		filter?: ISnapshotFilter,
-	): AsyncGenerator<ISnapshot<A>[]>;
-
-	/**
 	 * Get a snapshot from the snapshot stream.
 	 * @param snapshotStream The snapshot stream.
 	 * @param version The snapshot version.
@@ -64,6 +53,17 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 		version: number,
 		pool?: ISnapshotPool,
 	): ISnapshot<A> | Promise<ISnapshot<A>>;
+
+	/**
+	 * Get snapshots from the snapshot stream.
+	 * @param snapshotStream The snapshot stream.
+	 * @param filter The snapshot filter
+	 * @returns The snapshots.
+	 */
+	abstract getSnapshots<A extends AggregateRoot>(
+		snapshotStream: SnapshotStream,
+		filter?: ISnapshotFilter,
+	): AsyncGenerator<ISnapshot<A>[]>;
 
 	/**
 	 * Get the last snapshot from the snapshot stream.
@@ -139,12 +139,12 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 
 	/**
 	 * Get the last snapshot envelopes for a specified aggregate.
-	 * @param aggregateName The aggregate name.
+	 * @param aggregate The aggregate class.
 	 * @param filter The snapshot filter.
 	 * @returns The snapshot envelopes.
 	 */
-	abstract getLastAggregateEnvelopes?<A extends AggregateRoot>(
-		aggregateName: string,
+	abstract getLastEnvelopesForAggregate?<A extends AggregateRoot>(
+		aggregate: Type<A>,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]>;
 

--- a/packages/core/tests/unit/decorators/command-handler.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/command-handler.decorator.spec.ts
@@ -1,5 +1,10 @@
-import { CommandHandler, type ICommand, type ICommandHandler } from '@ocoda/event-sourcing';
-import { getCommandHandlerMetadata, getCommandMetadata } from '@ocoda/event-sourcing/helpers';
+import {
+	CommandHandler,
+	type ICommand,
+	type ICommandHandler,
+	getCommandHandlerMetadata,
+	getCommandMetadata,
+} from '@ocoda/event-sourcing';
 
 describe('@CommandHandler', () => {
 	class TestCommand implements ICommand {}

--- a/packages/core/tests/unit/decorators/event-handler.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/event-handler.decorator.spec.ts
@@ -1,6 +1,12 @@
-import { Aggregate, AggregateRoot, EventHandler, MissingEventMetadataException } from '@ocoda/event-sourcing';
-import { Event, type IEvent } from '@ocoda/event-sourcing';
-import { getEventHandlerMetadata } from '@ocoda/event-sourcing/helpers';
+import {
+	Aggregate,
+	AggregateRoot,
+	Event,
+	EventHandler,
+	type IEvent,
+	MissingEventMetadataException,
+	getEventHandlerMetadata,
+} from '@ocoda/event-sourcing';
 
 describe('@EventHandler', () => {
 	@Event()

--- a/packages/core/tests/unit/decorators/event-publisher.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/event-publisher.decorator.spec.ts
@@ -1,5 +1,4 @@
-import { EventPublisher, type IEventPublisher } from '@ocoda/event-sourcing';
-import { getEventPublisherMetadata } from '@ocoda/event-sourcing/helpers';
+import { EventPublisher, type IEventPublisher, getEventPublisherMetadata } from '@ocoda/event-sourcing';
 
 describe('@EventPublisher', () => {
 	@EventPublisher()

--- a/packages/core/tests/unit/decorators/event-serializer.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/event-serializer.decorator.spec.ts
@@ -1,5 +1,4 @@
-import { EventSerializer, type IEvent, type IEventSerializer } from '@ocoda/event-sourcing';
-import { getEventSerializerMetadata } from '@ocoda/event-sourcing/helpers';
+import { EventSerializer, type IEvent, type IEventSerializer, getEventSerializerMetadata } from '@ocoda/event-sourcing';
 
 describe('@EventSerializer', () => {
 	class AccountCreatedEvent implements IEvent {}

--- a/packages/core/tests/unit/decorators/event-subscriber.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/event-subscriber.decorator.spec.ts
@@ -1,5 +1,4 @@
-import { EventSubscriber, type IEvent, type IEventSubscriber } from '@ocoda/event-sourcing';
-import { getEventSubscriberMetadata } from '@ocoda/event-sourcing/helpers';
+import { EventSubscriber, type IEvent, type IEventSubscriber, getEventSubscriberMetadata } from '@ocoda/event-sourcing';
 
 describe('@EventSubscriber', () => {
 	class FooEvent implements IEvent {}

--- a/packages/core/tests/unit/decorators/event.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/event.decorator.spec.ts
@@ -1,5 +1,4 @@
-import { Event, type IEvent, InvalidEventStreamNameException } from '@ocoda/event-sourcing';
-import { getEventMetadata } from '@ocoda/event-sourcing/helpers';
+import { Event, type IEvent, InvalidEventStreamNameException, getEventMetadata } from '@ocoda/event-sourcing';
 
 describe('@Event', () => {
 	@Event('foo-created')

--- a/packages/core/tests/unit/decorators/query-handler.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/query-handler.decorator.spec.ts
@@ -1,5 +1,10 @@
-import { type IQuery, type IQueryHandler, QueryHandler } from '@ocoda/event-sourcing';
-import { getQueryHandlerMetadata, getQueryMetadata } from '@ocoda/event-sourcing/helpers';
+import {
+	type IQuery,
+	type IQueryHandler,
+	QueryHandler,
+	getQueryHandlerMetadata,
+	getQueryMetadata,
+} from '@ocoda/event-sourcing';
 
 describe('@QueryHandler', () => {
 	class TestQuery implements IQuery {}

--- a/packages/core/tests/unit/decorators/snapshot.decorator.spec.ts
+++ b/packages/core/tests/unit/decorators/snapshot.decorator.spec.ts
@@ -4,8 +4,8 @@ import {
 	SNAPSHOT_METADATA,
 	Snapshot,
 	type SnapshotRepositoryMetadata,
+	getSnapshotMetadata,
 } from '@ocoda/event-sourcing';
-import { getSnapshotMetadata } from '@ocoda/event-sourcing/helpers';
 
 describe('@Snapshot', () => {
 	class Account extends AggregateRoot {}

--- a/packages/core/tests/unit/event-store.spec.ts
+++ b/packages/core/tests/unit/event-store.spec.ts
@@ -1,0 +1,58 @@
+import {
+	Aggregate,
+	type EventEnvelope,
+	EventMap,
+	EventStore,
+	type IEvent,
+	type IEventCollection,
+	type IEventCollectionFilter,
+	type IEventPool,
+} from '@ocoda/event-sourcing';
+
+describe(EventStore, () => {
+	@Aggregate()
+	class FooEventStore extends EventStore {
+		public connect(): void | Promise<void> {}
+		public disconnect(): void | Promise<void> {}
+		public ensureCollection(pool?: IEventPool): IEventCollection | Promise<IEventCollection> {
+			return;
+		}
+		public listCollections(filter?: IEventCollectionFilter): AsyncGenerator<IEventCollection[]> {
+			return;
+		}
+		getEvent(): IEvent | Promise<IEvent> {
+			return;
+		}
+		getEvents(): AsyncGenerator<IEvent[]> {
+			return;
+		}
+		appendEvents(): Promise<EventEnvelope[]> {
+			return;
+		}
+		getEnvelopes?(): AsyncGenerator<EventEnvelope[]> {
+			return;
+		}
+		getEnvelope?(): EventEnvelope | Promise<EventEnvelope> {
+			return;
+		}
+		getAllEnvelopes(): AsyncGenerator<EventEnvelope[]> {
+			return;
+		}
+		getYearMonthRange(
+			sinceDate: { year: number; month: number },
+			untilDate?: { year: number; month: number },
+		): string[] {
+			return super.getYearMonthRange(sinceDate, untilDate);
+		}
+	}
+
+	const eventStore = new FooEventStore(new EventMap(), { useDefaultPool: false });
+
+	it('should calculate yearMonth values between two dates', () => {
+		expect(eventStore.getYearMonthRange({ year: 2021, month: 1 }, { year: 2021, month: 3 })).toEqual([
+			'2021-01',
+			'2021-02',
+			'2021-03',
+		]);
+	});
+});

--- a/packages/core/tests/unit/integration/event-store/in-memory.event-store.spec.ts
+++ b/packages/core/tests/unit/integration/event-store/in-memory.event-store.spec.ts
@@ -223,6 +223,35 @@ describe(InMemoryEventStore, () => {
 		}
 	});
 
+	it('should retrieve all event-envelopes since a specified time', async () => {
+		const seedAllEnvelopes = [...envelopesAccountA, ...envelopesAccountB].sort((a, b) =>
+			a.metadata.eventId.value < b.metadata.eventId.value ? -1 : 1,
+		);
+
+		const resolvedAllEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 } })) {
+			resolvedAllEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedAllEnvelopes).toHaveLength(envelopesAccountA.length + envelopesAccountB.length);
+
+		for (const [index, envelope] of resolvedAllEnvelopes.entries()) {
+			expect(envelope.event).toEqual(seedAllEnvelopes[index].event);
+			expect(envelope.payload).toEqual(seedAllEnvelopes[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(seedAllEnvelopes[index].metadata.aggregateId);
+			expect(envelope.metadata.eventId.value).toEqual(seedAllEnvelopes[index].metadata.eventId.value);
+			expect(envelope.metadata.version).toEqual(seedAllEnvelopes[index].metadata.version);
+		}
+	});
+
+	it('should retrieve all event-envelopes batched', async () => {
+		const resolvedBatchedEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 }, batch: 2 })) {
+			expect(envelopes.length).toBe(2);
+			resolvedBatchedEnvelopes.push(...envelopes);
+		}
+	});
+
 	it('should list collections', async () => {
 		await Promise.all([
 			eventStore.ensureCollection('a'),

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -192,7 +192,7 @@ describe(InMemorySnapshotStore, () => {
 	});
 
 	it('should retrieve multiple last snapshots', () => {
-		const resolvedSnapshots = snapshotStore.getManyLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
+		const resolvedSnapshots = snapshotStore.getLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -254,7 +254,7 @@ describe(InMemorySnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -264,7 +264,7 @@ describe(InMemorySnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
@@ -281,7 +281,7 @@ describe(InMemorySnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Account)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -266,7 +266,7 @@ describe(InMemorySnapshotStore, () => {
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
-			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+			aggregateId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
 			lastPageEnvelopes.push(...envelopes);
 		}

--- a/packages/core/tests/unit/models/ulid.spec.ts
+++ b/packages/core/tests/unit/models/ulid.spec.ts
@@ -6,6 +6,13 @@ describe(ULID, () => {
 		expect(generatedUlid.value).toBeDefined();
 	});
 
+	it('should return date information', () => {
+		const generatedUlid = ULID.from('01JAD3JSA97C385R2GKERK1VK7');
+		expect(generatedUlid.time).toBe(1729164305737);
+		expect(generatedUlid.date).toEqual(new Date(1729164305737));
+		expect(generatedUlid.yearMonth).toBe('2024-10');
+	});
+
 	it('should create a ULID from an existing value', () => {
 		const ulid = '01JA50F56AM0CCDBNVQW3TTWNY';
 		const createdULID = ULID.from(ulid);

--- a/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
+++ b/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
@@ -427,16 +427,16 @@ export class DynamoDBSnapshotStore extends SnapshotStore<DynamoDBSnapshotStoreCo
 		const collection = SnapshotCollection.get(filter?.pool);
 		const { streamName } = getAggregateMetadata(aggregate);
 
-		const fromId = filter?.fromId;
+		const aggregateId = filter?.aggregateId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
 		const KeyConditionExpression = ['aggregateName = :aggregateName'];
 		const ExpressionAttributeValues = { ':aggregateName': { S: streamName } };
 
-		if (fromId) {
+		if (aggregateId) {
 			KeyConditionExpression.push('latest > :latest');
-			ExpressionAttributeValues[':latest'] = { S: `latest#${fromId}` };
+			ExpressionAttributeValues[':latest'] = { S: `latest#${aggregateId}` };
 		} else {
 			KeyConditionExpression.push('begins_with(latest, :latest)');
 			ExpressionAttributeValues[':latest'] = { S: 'latest' };

--- a/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
+++ b/packages/integration/dynamodb/lib/dynamodb.snapshot-store.ts
@@ -293,7 +293,7 @@ export class DynamoDBSnapshotStore extends SnapshotStore<DynamoDBSnapshotStoreCo
 		}
 	}
 
-	async getManyLastSnapshots<A extends AggregateRoot>(
+	async getLastSnapshots<A extends AggregateRoot>(
 		streams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Promise<Map<SnapshotStream, ISnapshot<A>>> {

--- a/packages/integration/dynamodb/tests/unit/dynamodb.event-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.event-store.spec.ts
@@ -275,6 +275,35 @@ describe(DynamoDBEventStore, () => {
 		}
 	});
 
+	it('should retrieve all event-envelopes since a specified time', async () => {
+		const seedAllEnvelopes = [...envelopesAccountA, ...envelopesAccountB].sort((a, b) =>
+			a.metadata.eventId.value < b.metadata.eventId.value ? -1 : 1,
+		);
+
+		const resolvedAllEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 } })) {
+			resolvedAllEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedAllEnvelopes).toHaveLength(envelopesAccountA.length + envelopesAccountB.length);
+
+		for (const [index, envelope] of resolvedAllEnvelopes.entries()) {
+			expect(envelope.event).toEqual(seedAllEnvelopes[index].event);
+			expect(envelope.payload).toEqual(seedAllEnvelopes[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(seedAllEnvelopes[index].metadata.aggregateId);
+			expect(envelope.metadata.eventId.value).toEqual(seedAllEnvelopes[index].metadata.eventId.value);
+			expect(envelope.metadata.version).toEqual(seedAllEnvelopes[index].metadata.version);
+		}
+	});
+
+	it('should retrieve all event-envelopes batched', async () => {
+		const resolvedBatchedEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 }, batch: 2 })) {
+			expect(envelopes.length).toBe(2);
+			resolvedBatchedEnvelopes.push(...envelopes);
+		}
+	});
+
 	it('should list collections', async () => {
 		await Promise.all([
 			eventStore.ensureCollection('a'),

--- a/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
@@ -239,10 +239,7 @@ describe(DynamoDBSnapshotStore, () => {
 	});
 
 	it('should retrieve multiple last snapshots', async () => {
-		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
-			snapshotStreamAccountA,
-			snapshotStreamAccountB,
-		]);
+		const resolvedSnapshots = await snapshotStore.getLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
@@ -289,7 +289,7 @@ describe(DynamoDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Account)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -330,7 +330,7 @@ describe(DynamoDBSnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -340,7 +340,7 @@ describe(DynamoDBSnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {

--- a/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
+++ b/packages/integration/dynamodb/tests/unit/dynamodb.snapshot-store.spec.ts
@@ -342,7 +342,7 @@ describe(DynamoDBSnapshotStore, () => {
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
-			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+			aggregateId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
 			lastPageEnvelopes.push(...envelopes);
 		}

--- a/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
@@ -225,7 +225,7 @@ export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConf
 		}
 	}
 
-	async getManyLastSnapshots<A extends AggregateRoot>(
+	async getLastSnapshots<A extends AggregateRoot>(
 		streams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Promise<Map<SnapshotStream, ISnapshot<A>>> {

--- a/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
+++ b/packages/integration/mariadb/lib/mariadb.snapshot-store.ts
@@ -354,7 +354,7 @@ export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConf
 		const collection = SnapshotCollection.get(filter?.pool);
 		const { streamName } = getAggregateMetadata(aggregate);
 
-		const fromId = filter?.fromId;
+		const aggregateId = filter?.aggregateId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
@@ -362,11 +362,11 @@ export class MariaDBSnapshotStore extends SnapshotStore<MariaDBSnapshotStoreConf
 	        SELECT payload, aggregate_id, registered_on, snapshot_id, version
 	        FROM \`${collection}\`
 	        WHERE aggregate_name = ?
-	        AND ${fromId ? 'latest >= ?' : "latest LIKE 'latest%'"}
+	        AND ${aggregateId ? 'latest >= ?' : "latest LIKE 'latest%'"}
 	        LIMIT ?
 	    `;
 
-		const params = fromId ? [streamName, fromId, limit] : [streamName, limit];
+		const params = aggregateId ? [streamName, aggregateId, limit] : [streamName, limit];
 
 		const client = await connection;
 		const stream = client.queryStream(query, params);

--- a/packages/integration/mariadb/tests/unit/mariadb.event-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.event-store.spec.ts
@@ -258,6 +258,35 @@ describe(MariaDBEventStore, () => {
 		}
 	});
 
+	it('should retrieve all event-envelopes since a specified time', async () => {
+		const seedAllEnvelopes = [...envelopesAccountA, ...envelopesAccountB].sort((a, b) =>
+			a.metadata.eventId.value < b.metadata.eventId.value ? -1 : 1,
+		);
+
+		const resolvedAllEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 } })) {
+			resolvedAllEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedAllEnvelopes).toHaveLength(envelopesAccountA.length + envelopesAccountB.length);
+
+		for (const [index, envelope] of resolvedAllEnvelopes.entries()) {
+			expect(envelope.event).toEqual(seedAllEnvelopes[index].event);
+			expect(envelope.payload).toEqual(seedAllEnvelopes[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(seedAllEnvelopes[index].metadata.aggregateId);
+			expect(envelope.metadata.eventId.value).toEqual(seedAllEnvelopes[index].metadata.eventId.value);
+			expect(envelope.metadata.version).toEqual(seedAllEnvelopes[index].metadata.version);
+		}
+	});
+
+	it('should retrieve all event-envelopes batched', async () => {
+		const resolvedBatchedEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 }, batch: 2 })) {
+			expect(envelopes.length).toBe(2);
+			resolvedBatchedEnvelopes.push(...envelopes);
+		}
+	});
+
 	it('should list collections', async () => {
 		await Promise.all([
 			eventStore.ensureCollection('a'),

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -210,10 +210,7 @@ describe(MariaDBSnapshotStore, () => {
 	});
 
 	it('should retrieve multiple last snapshots', async () => {
-		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
-			snapshotStreamAccountA,
-			snapshotStreamAccountB,
-		]);
+		const resolvedSnapshots = await snapshotStore.getLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -304,7 +304,7 @@ describe(MariaDBSnapshotStore, () => {
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
-			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+			aggregateId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
 			lastPageEnvelopes.push(...envelopes);
 		}

--- a/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
+++ b/packages/integration/mariadb/tests/unit/mariadb.snapshot-store.spec.ts
@@ -256,7 +256,7 @@ describe(MariaDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Account)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 		expect(resolvedEnvelopes).toHaveLength(2);
@@ -292,7 +292,7 @@ describe(MariaDBSnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -302,7 +302,7 @@ describe(MariaDBSnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {

--- a/packages/integration/mongodb/lib/interfaces/mongodb-event-entity.ts
+++ b/packages/integration/mongodb/lib/interfaces/mongodb-event-entity.ts
@@ -3,6 +3,7 @@ import type { Document } from 'mongodb';
 
 export type MongoDBEventEntity = {
 	_id: string; // the eventId
+	eventDate: string; // YYYY-MM
 	streamId: string;
 	event: string;
 	payload: IEventPayload<IEvent>;

--- a/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
@@ -210,7 +210,7 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 		}
 	}
 
-	async getManyLastSnapshots<A extends AggregateRoot>(
+	async getLastSnapshots<A extends AggregateRoot>(
 		streams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Promise<Map<SnapshotStream, ISnapshot<A>>> {

--- a/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
+++ b/packages/integration/mongodb/lib/mongodb.snapshot-store.ts
@@ -330,7 +330,7 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 		const collection = SnapshotCollection.get(filter?.pool);
 		const { streamName } = getAggregateMetadata(aggregate);
 
-		const fromId = filter?.fromId;
+		const aggregateId = filter?.aggregateId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
@@ -341,7 +341,7 @@ export class MongoDBSnapshotStore extends SnapshotStore<MongoDBSnapshotStoreConf
 			.find(
 				{
 					aggregateName: streamName,
-					...(fromId ? { latest: { $gte: fromId } } : { latest: { $regex: /^latest/ } }),
+					...(aggregateId ? { latest: { $gte: aggregateId } } : { latest: { $regex: /^latest/ } }),
 				},
 				{
 					sort: { latest: -1 },

--- a/packages/integration/mongodb/tests/unit/mongodb.event-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.event-store.spec.ts
@@ -258,6 +258,35 @@ describe(MongoDBEventStore, () => {
 		}
 	});
 
+	it('should retrieve all event-envelopes since a specified time', async () => {
+		const seedAllEnvelopes = [...envelopesAccountA, ...envelopesAccountB].sort((a, b) =>
+			a.metadata.eventId.value < b.metadata.eventId.value ? -1 : 1,
+		);
+
+		const resolvedAllEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 } })) {
+			resolvedAllEnvelopes.push(...envelopes);
+		}
+
+		expect(resolvedAllEnvelopes).toHaveLength(envelopesAccountA.length + envelopesAccountB.length);
+
+		for (const [index, envelope] of resolvedAllEnvelopes.entries()) {
+			expect(envelope.event).toEqual(seedAllEnvelopes[index].event);
+			expect(envelope.payload).toEqual(seedAllEnvelopes[index].payload);
+			expect(envelope.metadata.aggregateId).toEqual(seedAllEnvelopes[index].metadata.aggregateId);
+			expect(envelope.metadata.eventId.value).toEqual(seedAllEnvelopes[index].metadata.eventId.value);
+			expect(envelope.metadata.version).toEqual(seedAllEnvelopes[index].metadata.version);
+		}
+	});
+
+	it('should retrieve all event-envelopes batched', async () => {
+		const resolvedBatchedEnvelopes: EventEnvelope[] = [];
+		for await (const envelopes of eventStore.getAllEnvelopes({ since: { year: 2021, month: 1 }, batch: 2 })) {
+			expect(envelopes.length).toBe(2);
+			resolvedBatchedEnvelopes.push(...envelopes);
+		}
+	});
+
 	it('should list collections', async () => {
 		await Promise.all([
 			eventStore.ensureCollection('a'),

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -241,7 +241,7 @@ describe(MongoDBSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Account)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 
@@ -282,7 +282,7 @@ describe(MongoDBSnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -292,7 +292,7 @@ describe(MongoDBSnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -204,10 +204,7 @@ describe(MongoDBSnapshotStore, () => {
 	});
 
 	it('should retrieve multiple last snapshots', async () => {
-		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
-			snapshotStreamAccountA,
-			snapshotStreamAccountB,
-		]);
+		const resolvedSnapshots = await snapshotStore.getLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
+++ b/packages/integration/mongodb/tests/unit/mongodb.snapshot-store.spec.ts
@@ -294,7 +294,7 @@ describe(MongoDBSnapshotStore, () => {
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
-			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+			aggregateId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
 			lastPageEnvelopes.push(...envelopes);
 		}

--- a/packages/integration/postgres/lib/postgres.snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres.snapshot-store.ts
@@ -363,7 +363,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 		const collection = SnapshotCollection.get(filter?.pool);
 		const { streamName } = getAggregateMetadata(aggregate);
 
-		const fromId = filter?.fromId;
+		const aggregateId = filter?.aggregateId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
@@ -371,12 +371,12 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
             SELECT payload, aggregate_id, registered_on, snapshot_id, version
             FROM "${collection}"
             WHERE aggregate_name = $1
-            AND ${fromId ? 'latest >= $2' : "latest LIKE 'latest%'"}
+            AND ${aggregateId ? 'latest >= $2' : "latest LIKE 'latest%'"}
             ORDER BY latest DESC
-            LIMIT ${fromId ? '$3' : '$2'}
+            LIMIT ${aggregateId ? '$3' : '$2'}
         `;
 
-		const params = fromId ? [streamName, fromId, limit] : [streamName, limit];
+		const params = aggregateId ? [streamName, aggregateId, limit] : [streamName, limit];
 
 		const cursor = this.client.query(
 			new Cursor<

--- a/packages/integration/postgres/lib/postgres.snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres.snapshot-store.ts
@@ -234,7 +234,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 		}
 	}
 
-	async getManyLastSnapshots<A extends AggregateRoot>(
+	async getLastSnapshots<A extends AggregateRoot>(
 		streams: SnapshotStream[],
 		pool?: ISnapshotPool,
 	): Promise<Map<SnapshotStream, ISnapshot<A>>> {

--- a/packages/integration/postgres/lib/postgres.snapshot-store.ts
+++ b/packages/integration/postgres/lib/postgres.snapshot-store.ts
@@ -1,3 +1,4 @@
+import type { Type } from '@nestjs/common';
 import {
 	type AggregateRoot,
 	DEFAULT_BATCH_SIZE,
@@ -16,6 +17,7 @@ import {
 	SnapshotStoreVersionConflictException,
 	type SnapshotStream,
 	StreamReadingDirection,
+	getAggregateMetadata,
 } from '@ocoda/event-sourcing';
 import { Pool, type PoolClient } from 'pg';
 import Cursor from 'pg-cursor';
@@ -354,11 +356,12 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
 		});
 	}
 
-	async *getLastAggregateEnvelopes<A extends AggregateRoot>(
-		aggregateName: string,
+	async *getLastEnvelopesForAggregate<A extends AggregateRoot>(
+		aggregate: Type<A>,
 		filter?: ILatestSnapshotFilter,
 	): AsyncGenerator<SnapshotEnvelope<A>[]> {
 		const collection = SnapshotCollection.get(filter?.pool);
+		const { streamName } = getAggregateMetadata(aggregate);
 
 		const fromId = filter?.fromId;
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
@@ -373,7 +376,7 @@ export class PostgresSnapshotStore extends SnapshotStore<PostgresSnapshotStoreCo
             LIMIT ${fromId ? '$3' : '$2'}
         `;
 
-		const params = fromId ? [aggregateName, fromId, limit] : [aggregateName, limit];
+		const params = fromId ? [streamName, fromId, limit] : [streamName, limit];
 
 		const cursor = this.client.query(
 			new Cursor<

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -260,7 +260,7 @@ describe(PostgresSnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelopes for an aggregate', async () => {
 		let resolvedEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('account')) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Account)) {
 			resolvedEnvelopes.push(...envelopes);
 		}
 		expect(resolvedEnvelopes).toHaveLength(2);
@@ -296,7 +296,7 @@ describe(PostgresSnapshotStore, () => {
 
 		const fetchedAccountIds: Set<string> = new Set();
 		const firstPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', { limit: 15 })) {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, { limit: 15 })) {
 			firstPageEnvelopes.push(...envelopes);
 		}
 
@@ -306,7 +306,7 @@ describe(PostgresSnapshotStore, () => {
 		}
 
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
-		for await (const envelopes of snapshotStore.getLastAggregateEnvelopes('foo', {
+		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
 			fromId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -308,7 +308,7 @@ describe(PostgresSnapshotStore, () => {
 		const lastPageEnvelopes: SnapshotEnvelope<Account>[] = [];
 		for await (const envelopes of snapshotStore.getLastEnvelopesForAggregate(Foo, {
 			limit: 5,
-			fromId: firstPageEnvelopes[14].metadata.aggregateId,
+			aggregateId: firstPageEnvelopes[14].metadata.aggregateId,
 		})) {
 			lastPageEnvelopes.push(...envelopes);
 		}

--- a/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
+++ b/packages/integration/postgres/tests/unit/postgres.snapshot-store.spec.ts
@@ -214,10 +214,7 @@ describe(PostgresSnapshotStore, () => {
 	});
 
 	it('should retrieve multiple last snapshots', async () => {
-		const resolvedSnapshots = await snapshotStore.getManyLastSnapshots([
-			snapshotStreamAccountA,
-			snapshotStreamAccountB,
-		]);
+		const resolvedSnapshots = await snapshotStore.getLastSnapshots([snapshotStreamAccountA, snapshotStreamAccountB]);
 
 		expect(resolvedSnapshots.size).toBe(2);
 		expect(resolvedSnapshots.get(snapshotStreamAccountA)).toEqual(snapshotsAccountA[snapshotsAccountA.length - 1]);

--- a/packages/testing/e2e/application/repositories/account.repository.ts
+++ b/packages/testing/e2e/application/repositories/account.repository.ts
@@ -38,7 +38,7 @@ export class AccountRepository {
 	async getAll(fromAccountId?: AccountId, limit?: number): Promise<Account[]> {
 		const accounts = [];
 		for await (const envelopes of this.accountSnapshotRepository.loadAll({
-			fromId: fromAccountId,
+			aggregateId: fromAccountId,
 			limit,
 			pool: 'e2e',
 		})) {
@@ -61,7 +61,7 @@ export class AccountRepository {
 		const events = account.commit();
 		const stream = EventStream.for<Account>(Account, account.id);
 
-        await this.eventStore.appendEvents(stream, account.version, events, 'e2e');
-        await this.accountSnapshotRepository.save(account.id, account, 'e2e');
+		await this.eventStore.appendEvents(stream, account.version, events, 'e2e');
+		await this.accountSnapshotRepository.save(account.id, account, 'e2e');
 	}
 }

--- a/packages/testing/unit/index.ts
+++ b/packages/testing/unit/index.ts
@@ -56,27 +56,27 @@ export const getAccountAEventEnvelopes = (eventMap: EventMap, events: IEvent[]):
 	EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
 		aggregateId: idAccountA.value,
 		version: 2,
-		eventId: EventId.generate(new Date('2021-01-01T00:00:20Z')),
+		eventId: EventId.generate(new Date('2021-02-01T00:00:20Z')),
 	}),
 	EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
 		aggregateId: idAccountA.value,
 		version: 3,
-		eventId: EventId.generate(new Date('2021-01-01T00:00:40Z')),
+		eventId: EventId.generate(new Date('2021-02-01T00:00:40Z')),
 	}),
 	EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
 		aggregateId: idAccountA.value,
 		version: 4,
-		eventId: EventId.generate(new Date('2021-01-01T00:01:00Z')),
+		eventId: EventId.generate(new Date('2021-03-01T00:01:00Z')),
 	}),
 	EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
 		aggregateId: idAccountA.value,
 		version: 5,
-		eventId: EventId.generate(new Date('2021-01-01T00:01:20Z')),
+		eventId: EventId.generate(new Date('2021-03-01T00:01:20Z')),
 	}),
 	EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
 		aggregateId: idAccountA.value,
 		version: 6,
-		eventId: EventId.generate(new Date('2021-01-02T00:01:40Z')),
+		eventId: EventId.generate(new Date('2021-05-01T00:01:40Z')),
 	}),
 ];
 export const snapshotStreamAccountA = SnapshotStream.for(Account, idAccountA);
@@ -121,27 +121,27 @@ export const getAccountBEventEnvelopes = (eventMap: EventMap, events: IEvent[]):
 	EventEnvelope.create('account-credited', eventMap.serializeEvent(events[1]), {
 		aggregateId: idAccountB.value,
 		version: 2,
-		eventId: EventId.generate(new Date('2021-01-01T00:00:30Z')),
+		eventId: EventId.generate(new Date('2021-02-01T00:00:30Z')),
 	}),
 	EventEnvelope.create('account-debited', eventMap.serializeEvent(events[2]), {
 		aggregateId: idAccountB.value,
 		version: 3,
-		eventId: EventId.generate(new Date('2021-01-01T00:00:50Z')),
+		eventId: EventId.generate(new Date('2021-02-01T00:00:50Z')),
 	}),
 	EventEnvelope.create('account-credited', eventMap.serializeEvent(events[3]), {
 		aggregateId: idAccountB.value,
 		version: 4,
-		eventId: EventId.generate(new Date('2021-01-01T00:01:10Z')),
+		eventId: EventId.generate(new Date('2021-03-01T00:01:10Z')),
 	}),
 	EventEnvelope.create('account-debited', eventMap.serializeEvent(events[4]), {
 		aggregateId: idAccountB.value,
 		version: 5,
-		eventId: EventId.generate(new Date('2021-01-01T00:01:30Z')),
+		eventId: EventId.generate(new Date('2021-03-01T00:01:30Z')),
 	}),
 	EventEnvelope.create('account-closed', eventMap.serializeEvent(events[5]), {
 		aggregateId: idAccountB.value,
 		version: 6,
-		eventId: EventId.generate(new Date('2021-01-02T00:01:50Z')),
+		eventId: EventId.generate(new Date('2021-05-01T00:01:50Z')),
 	}),
 ];
 export const snapshotStreamAccountB = SnapshotStream.for(Account, idAccountB);


### PR DESCRIPTION
- **♻️ rename getLastAggregateEnvelopes to getLastEnvelopesForAggregate**
- **:recycle: rename fromId parameters to aggregateId**
- **:recycle: rename getManyLastSnapshots to getLastSnapshots**
- **:sparkles: add a getAllEnvelopes method to the abstract event-store**
- **✅ update tests to assert the getAllEnvelopes method on all event-stores**
- **:sparkles: add a separate filter for fetching all events**
- **🗃️ add additional indices and add a getAllEnvelopes method to each event-store**

# Description

- renames some methods
- adds a getAllEnvelopes method to all event-stores
- adjusts the indices to match that logic

Fixes #370

