### PR TITLE
DOCS: multitenancy-update-to-guide-#3

### DIFF
--- a/docs/pages/advanced/multitenancy.mdx
+++ b/docs/pages/advanced/multitenancy.mdx
@@ -49,6 +49,10 @@ This library makes a distinction between the types for pools and for collections
 
   ```typescript copy
     await this.eventStore.appendEvents(stream, account.version, events, 'tenant-1');
+    await this.eventStore.getEvents(eventStream, {
+      fromVersion: account.version + 1,
+      pool: 'tenant-1'
+    });
     await this.accountSnapshotRepository.save(accountId, account, 'tenant-1');
     await this.accountSnapshotRepository.load(accountId, 'tenant-1');
   ```


### PR DESCRIPTION
The EventStore generator method: `getEvents`, also requires `pool` argument to be supplied when interacting with the store in the case of custom `pool` name.
Since this is not specified in the docs alongside others, this is a request to include it.