### PR TITLE
Enable strictNullChecks in Typescript to fix multiple typing errors

### DIFF
--- a/packages/config/typescript/base.json
+++ b/packages/config/typescript/base.json
@@ -9,7 +9,8 @@
 		"experimentalDecorators": true,
 		"target": "es6",
 		"sourceMap": false,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"strictNullChecks": true
 	},
 	"exclude": ["dist", "node_modules"]
 }

--- a/packages/core/lib/decorators/aggregate.decorator.ts
+++ b/packages/core/lib/decorators/aggregate.decorator.ts
@@ -17,7 +17,7 @@ export const Aggregate = (options?: AggregateMetadata): ClassDecorator => {
 		const { name } = target as Type<AggregateRoot>;
 		const metadata: AggregateMetadata = { streamName: name.toLowerCase(), ...options };
 
-		if (metadata.streamName.length > 50) {
+		if ((metadata.streamName?.length || 0) > 50) {
 			throw InvalidAggregateStreamNameException.becauseExceedsMaxLength(name, 50);
 		}
 

--- a/packages/core/lib/event-map.ts
+++ b/packages/core/lib/event-map.ts
@@ -23,7 +23,7 @@ export type IEventMapTarget<E extends IEvent = IEvent> = IEventName | IEventCons
 
 @Injectable()
 export class EventMap {
-	private readonly eventMap: Set<IEventData<unknown>> = new Set();
+	private readonly eventMap: Set<IEventData<IEvent>> = new Set();
 
 	public register<E extends IEvent>(cls: IEventConstructor<E>, serializer?: IEventSerializer): void {
 		const { name } = getEventMetadata(cls);

--- a/packages/core/lib/exceptions/application/unregistered-event.exception.ts
+++ b/packages/core/lib/exceptions/application/unregistered-event.exception.ts
@@ -17,6 +17,10 @@ export class UnregisteredEventException extends Error {
 				name = target.name;
 				break;
 			}
+			default: {
+				name = 'unknown';
+				break;
+			}
 		}
 
 		super(`Event '${name}' is not registered. Register it in the EventSourcingModule.`);

--- a/packages/core/lib/integration/event-store/in-memory.event-store.ts
+++ b/packages/core/lib/integration/event-store/in-memory.event-store.ts
@@ -75,7 +75,8 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
-		entities = this.collections.get(collection).filter(({ streamId: entityStreamId }) => entityStreamId === streamId);
+		entities =
+			this.collections.get(collection)?.filter(({ streamId: entityStreamId }) => entityStreamId === streamId) || [];
 
 		if (fromVersion) {
 			entities = entities.filter(({ version }) => version >= fromVersion);
@@ -207,7 +208,8 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 		const limit = filter?.limit || Number.MAX_SAFE_INTEGER;
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
-		entities = this.collections.get(collection).filter(({ streamId: entityStreamId }) => entityStreamId === streamId);
+		entities =
+			this.collections.get(collection)?.filter(({ streamId: entityStreamId }) => entityStreamId === streamId) || [];
 
 		if (fromVersion) {
 			entities = entities.filter(({ version }) => version >= fromVersion);
@@ -244,8 +246,7 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 
 		const batch = filter?.batch || DEFAULT_BATCH_SIZE;
 
-		entities = this.collections
-			.get(collection)
+		entities = (this.collections.get(collection) || [])
 			.filter(({ occurredOn }) => {
 				const delta = new Date(occurredOn).getTime();
 				return since <= delta && delta <= until;
@@ -269,7 +270,7 @@ export class InMemoryEventStore extends EventStore<InMemoryEventStoreConfig> {
 
 	private getDateRange(
 		sinceDate: { year: number; month: number },
-		untilDate: { year: number; month: number },
+		untilDate?: { year: number; month: number },
 	): { since: number; until: number } {
 		const now = new Date();
 		const [untilYear, untilMonth] = untilDate

--- a/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
+++ b/packages/core/lib/integration/snapshot-store/in-memory.snapshot-store.ts
@@ -24,7 +24,7 @@ export type InMemorySnapshotEntity<A extends AggregateRoot> = {
 	streamId: string;
 	payload: ISnapshot<A>;
 	aggregateName: string;
-	latest?: string;
+	latest: string | null;
 } & SnapshotEnvelopeMetadata;
 
 export interface InMemorySnapshotStoreConfig extends SnapshotStoreConfig {
@@ -150,7 +150,7 @@ export class InMemorySnapshotStore extends SnapshotStore<InMemorySnapshotStoreCo
 
 			for (const entity of snapshotCollection) {
 				if (entity.streamId === stream.streamId) {
-					entity.latest = undefined;
+					entity.latest = null;
 				}
 			}
 

--- a/packages/core/lib/snapshot-store.ts
+++ b/packages/core/lib/snapshot-store.ts
@@ -74,7 +74,7 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	abstract getLastSnapshot<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
-	): ISnapshot<A> | Promise<ISnapshot<A>>;
+	): ISnapshot<A> | void | Promise<ISnapshot<A> | void>;
 
 	/**
 	 * Get the last snapshot from multiple snapshot streams.
@@ -111,7 +111,7 @@ export abstract class SnapshotStore<TOptions = Omit<EventSourcingModuleOptions['
 	abstract getLastEnvelope<A extends AggregateRoot>(
 		snapshotStream: SnapshotStream,
 		pool?: ISnapshotPool,
-	): SnapshotEnvelope<A> | Promise<SnapshotEnvelope<A>>;
+	): SnapshotEnvelope<A> | void | Promise<SnapshotEnvelope<A> | void>;
 
 	/**
 	 * Get the last snapshot envelopes from the snapshot stream.

--- a/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
+++ b/packages/core/tests/unit/integration/snapshot-store/in-memory.snapshot-store.spec.ts
@@ -32,7 +32,7 @@ describe(InMemorySnapshotStore, () => {
 	const envelopesAccountB = snapshotEnvelopesAccountB;
 
 	beforeAll(() => {
-		snapshotStore = new InMemorySnapshotStore({ driver: undefined });
+		snapshotStore = new InMemorySnapshotStore({ driver: InMemorySnapshotStore });
 
 		snapshotStore.connect();
 		snapshotStore.ensureCollection();
@@ -229,7 +229,13 @@ describe(InMemorySnapshotStore, () => {
 
 	it('should retrieve the last snapshot-envelope', async () => {
 		const lastEnvelope = envelopesAccountA[envelopesAccountA.length - 1];
-		const { metadata, payload } = snapshotStore.getLastEnvelope(snapshotStreamAccountA);
+		const snapshotEnvelope = snapshotStore.getLastEnvelope(snapshotStreamAccountA);
+
+		if (!snapshotEnvelope) {
+			throw new Error('Snapshot envelope not found');
+		}
+
+		const { metadata, payload } = snapshotEnvelope;
 
 		expect(payload).toEqual(lastEnvelope.payload);
 		expect(metadata.aggregateId).toEqual(lastEnvelope.metadata.aggregateId);
@@ -320,6 +326,10 @@ describe(InMemorySnapshotStore, () => {
 
 		const resolvedAccountAEnvelope = resolvedSnapshots.get(snapshotStreamAccountA);
 		const resolvedAccountBEnvelope = resolvedSnapshots.get(snapshotStreamAccountB);
+
+		if (!resolvedAccountAEnvelope || !resolvedAccountBEnvelope) {
+			throw new Error('Snapshot envelope not found');
+		}
 
 		expect(resolvedAccountAEnvelope.payload).toEqual(envelopeAccountA.payload);
 		expect(resolvedAccountAEnvelope.metadata.aggregateId).toEqual(envelopeAccountA.metadata.aggregateId);

--- a/packages/integration/mariadb/lib/mariadb.event-store.ts
+++ b/packages/integration/mariadb/lib/mariadb.event-store.ts
@@ -239,8 +239,8 @@ export class MariaDBEventStore extends EventStore<MariaDBEventStoreConfig> {
 			aggregateId: entity.aggregate_id,
 			version: entity.version,
 			occurredOn: entity.occurred_on,
-			correlationId: entity.correlation_id,
-			causationId: entity.causation_id,
+			correlationId: entity.correlation_id ?? undefined,
+			causationId: entity.causation_id ?? undefined,
 		});
 	}
 
@@ -285,8 +285,8 @@ export class MariaDBEventStore extends EventStore<MariaDBEventStoreConfig> {
 						aggregateId: aggregate_id,
 						version,
 						occurredOn: occurred_on,
-						correlationId: correlation_id,
-						causationId: causation_id,
+						correlationId: correlation_id ?? undefined,
+						causationId: causation_id ?? undefined,
 					}),
 				);
 				if (batchedEvents.length === batch) {
@@ -341,8 +341,8 @@ export class MariaDBEventStore extends EventStore<MariaDBEventStoreConfig> {
 						aggregateId: aggregate_id,
 						version,
 						occurredOn: occurred_on,
-						correlationId: correlation_id,
-						causationId: causation_id,
+						correlationId: correlation_id ?? undefined,
+						causationId: causation_id ?? undefined,
 					}),
 				);
 				if (batchedEvents.length === batch) {

--- a/packages/integration/mongodb/lib/mongodb.event-store.ts
+++ b/packages/integration/mongodb/lib/mongodb.event-store.ts
@@ -68,7 +68,9 @@ export class MongoDBEventStore extends EventStore<MongoDBEventStoreConfig> {
 			const entity = await cursor.next();
 			hasNext = entity !== null;
 
-			hasNext && entities.push(entity.name as IEventCollection);
+			if (entity) {
+				entities.push(entity.name as IEventCollection);
+			}
 
 			if (entities.length > 0 && (entities.length === batch || !hasNext)) {
 				yield entities;
@@ -100,13 +102,15 @@ export class MongoDBEventStore extends EventStore<MongoDBEventStoreConfig> {
 			)
 			.map(({ event, payload }) => this.eventMap.deserializeEvent(event, payload));
 
-		const entities = [];
+		const entities: IEvent[] = [];
 		let hasNext: boolean;
 		do {
 			const entity = await cursor.next();
 			hasNext = entity !== null;
 
-			hasNext && entities.push(entity);
+			if (entity) {
+				entities.push(entity);
+			}
 
 			if (entities.length > 0 && (entities.length === batch || !hasNext)) {
 				yield entities;
@@ -297,13 +301,15 @@ export class MongoDBEventStore extends EventStore<MongoDBEventStoreConfig> {
 				}),
 			);
 
-		const entities = [];
+		const entities: EventEnvelope<IEvent>[] = [];
 		let hasNext: boolean;
 		do {
 			const entity = await cursor.next();
 			hasNext = entity !== null;
 
-			hasNext && entities.push(entity);
+			if (entity) {
+				entities.push(entity);
+			}
 
 			if (entities.length > 0 && (entities.length === batch || !hasNext)) {
 				yield entities;
@@ -352,13 +358,15 @@ export class MongoDBEventStore extends EventStore<MongoDBEventStoreConfig> {
 				}),
 			);
 
-		const entities = [];
+		const entities: EventEnvelope<IEvent>[] = [];
 		let hasNext: boolean;
 		do {
 			const entity = await cursor.next();
 			hasNext = entity !== null;
 
-			hasNext && entities.push(entity);
+			if (entity) {
+				entities.push(entity);
+			}
 
 			if (entities.length > 0 && (entities.length === batch || !hasNext)) {
 				yield entities;

--- a/packages/integration/postgres/lib/postgres.event-store.ts
+++ b/packages/integration/postgres/lib/postgres.event-store.ts
@@ -243,8 +243,8 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 			aggregateId: entity.aggregate_id,
 			version: entity.version,
 			occurredOn: entity.occurred_on,
-			correlationId: entity.correlation_id,
-			causationId: entity.causation_id,
+			correlationId: entity.correlation_id ?? undefined,
+			causationId: entity.causation_id ?? undefined,
 		});
 	}
 
@@ -313,8 +313,8 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 							aggregateId: aggregate_id,
 							version,
 							occurredOn: occurred_on,
-							correlationId: correlation_id,
-							causationId: causation_id,
+							correlationId: correlation_id ?? undefined,
+							causationId: causation_id ?? undefined,
 						}),
 				);
 				yield entities;
@@ -385,8 +385,8 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 							aggregateId: aggregate_id,
 							version,
 							occurredOn: occurred_on,
-							correlationId: correlation_id,
-							causationId: causation_id,
+							correlationId: correlation_id ?? undefined,
+							causationId: causation_id ?? undefined,
 						}),
 				);
 				yield entities;


### PR DESCRIPTION
Hi,

First of all, thanks for your library :)

I started to use it and noticed a few things to improve to make it production ready for our use cases, especially the need for transactions when we create multiple events for multiple aggregates.

To do this I created a custom Event Store and a custom Snapshot Store (for other use cases), and I noticed some null types not being handled correctly with my stricter Typescript config, for instance : some functions can return void but it was not explicitly typed.

This PR enables the strictNullChecks and fix all types that was wrong.

Thanks again for your work, and if you don't mind I'll probably push more PR to add my required functions to your lib :).