### PR TITLE
[BUG-432] Fix NestJS peer dependency version

### DIFF
--- a/.changeset/eighty-ravens-matter.md
+++ b/.changeset/eighty-ravens-matter.md
@@ -1,0 +1,9 @@
+---
+"@ocoda/event-sourcing-dynamodb": patch
+"@ocoda/event-sourcing-postgres": patch
+"@ocoda/event-sourcing-mariadb": patch
+"@ocoda/event-sourcing-mongodb": patch
+"@ocoda/event-sourcing": patch
+---
+
+Bump dependencies

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
 		"node": ">= 20.0.0"
 	},
 	"peerDependencies": {
-		"@nestjs/common": "^10.0.0",
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,8 @@
 		"ulidx": "^2.4.1"
 	},
 	"peerDependencies": {
-		"@nestjs/common": "^10.0.0",
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/common": "^11.0.0",
+		"@nestjs/core": "^11.0.0",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"
 	},

--- a/packages/integration/dynamodb/package.json
+++ b/packages/integration/dynamodb/package.json
@@ -25,7 +25,7 @@
 		"@aws-sdk/util-dynamodb": "3.782.0"
 	},
 	"peerDependencies": {
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/core": "^11.0.0",
 		"@ocoda/event-sourcing": "workspace:*",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"

--- a/packages/integration/mariadb/package.json
+++ b/packages/integration/mariadb/package.json
@@ -24,7 +24,7 @@
 		"mariadb": "^3.4.1"
 	},
 	"peerDependencies": {
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/core": "^11.0.0",
 		"@ocoda/event-sourcing": "workspace:*",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"

--- a/packages/integration/mongodb/package.json
+++ b/packages/integration/mongodb/package.json
@@ -24,7 +24,7 @@
 		"mongodb": "^6.15.0"
 	},
 	"peerDependencies": {
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/core": "^11.0.0",
 		"@ocoda/event-sourcing": "workspace:*",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"

--- a/packages/integration/postgres/package.json
+++ b/packages/integration/postgres/package.json
@@ -25,7 +25,7 @@
 		"pg-cursor": "^2.13.1"
 	},
 	"peerDependencies": {
-		"@nestjs/core": "^10.0.0",
+		"@nestjs/core": "^11.0.0",
 		"@ocoda/event-sourcing": "workspace:*",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.2.0"


### PR DESCRIPTION
- **⬆️ bump nestjs peer dependencies**
- **🔖 add a changeset**

# Description

Fixes the NestJS peer dependency versions, which are now set to NestJS v11.

Fixes #[BUG-432](https://github.com/ocoda/event-sourcing/issues/432)

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

