### PR TITLE
[499] Fix serializing event payloads to save to Postgres

### DIFF
--- a/.changeset/honest-kiwis-hear.md
+++ b/.changeset/honest-kiwis-hear.md
@@ -1,0 +1,9 @@
+---
+"@ocoda/event-sourcing-postgres": patch
+"@ocoda/event-sourcing": patch
+"@ocoda/event-sourcing-dynamodb": patch
+"@ocoda/event-sourcing-mariadb": patch
+"@ocoda/event-sourcing-mongodb": patch
+---
+
+Fix serializing event payloads to save to Postgres

--- a/packages/integration/postgres/lib/postgres.event-store.ts
+++ b/packages/integration/postgres/lib/postgres.event-store.ts
@@ -243,7 +243,19 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 	async getEnvelope({ streamId }: EventStream, version: number, pool?: IEventPool): Promise<EventEnvelope> {
 		const collection = EventCollection.get(pool);
 
-		const { rows: entities } = await this.client.query<PostgresEventEntity>(
+		const { rows: entities } = await this.client.query<
+			Pick<
+				PostgresEventEntity,
+				| 'event'
+				| 'payload'
+				| 'event_id'
+				| 'aggregate_id'
+				| 'version'
+				| 'occurred_on'
+				| 'correlation_id'
+				| 'causation_id'
+			>
+		>(
 			`SELECT event, payload, event_id, aggregate_id, version, occurred_on, correlation_id, causation_id FROM "${collection}" WHERE stream_id = $1 AND version = $2`,
 			[streamId, version],
 		);
@@ -283,12 +295,38 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 
 		const params = fromVersion ? [streamId, fromVersion, limit] : [streamId, limit];
 
-		const cursor = this.client.query(new Cursor<PostgresEventEntity>(query, params));
+		const cursor = this.client.query(
+			new Cursor<
+				Pick<
+					PostgresEventEntity,
+					| 'event'
+					| 'payload'
+					| 'event_id'
+					| 'aggregate_id'
+					| 'version'
+					| 'occurred_on'
+					| 'correlation_id'
+					| 'causation_id'
+				>
+			>(query, params),
+		);
 
 		let done = false;
 
 		while (!done) {
-			const rows: PostgresEventEntity[] = await new Promise((resolve, reject) =>
+			const rows: Array<
+				Pick<
+					PostgresEventEntity,
+					| 'event'
+					| 'payload'
+					| 'event_id'
+					| 'aggregate_id'
+					| 'version'
+					| 'occurred_on'
+					| 'correlation_id'
+					| 'causation_id'
+				>
+			> = await new Promise((resolve, reject) =>
 				cursor.read(batch, (err, result) => (err ? reject(err) : resolve(result))),
 			);
 
@@ -329,12 +367,38 @@ export class PostgresEventStore extends EventStore<PostgresEventStoreConfig> {
 
 		const params = [yearMonths];
 
-		const cursor = this.client.query(new Cursor<PostgresEventEntity>(query, params));
+		const cursor = this.client.query(
+			new Cursor<
+				Pick<
+					PostgresEventEntity,
+					| 'event'
+					| 'payload'
+					| 'event_id'
+					| 'aggregate_id'
+					| 'version'
+					| 'occurred_on'
+					| 'correlation_id'
+					| 'causation_id'
+				>
+			>(query, params),
+		);
 
 		let done = false;
 
 		while (!done) {
-			const rows: PostgresEventEntity[] = await new Promise((resolve, reject) =>
+			const rows: Array<
+				Pick<
+					PostgresEventEntity,
+					| 'event'
+					| 'payload'
+					| 'event_id'
+					| 'aggregate_id'
+					| 'version'
+					| 'occurred_on'
+					| 'correlation_id'
+					| 'causation_id'
+				>
+			> = await new Promise((resolve, reject) =>
 				cursor.read(batch, (err, result) => (err ? reject(err) : resolve(result))),
 			);
 

--- a/packages/testing/unit/index.ts
+++ b/packages/testing/unit/index.ts
@@ -30,7 +30,7 @@ export class Account extends AggregateRoot {
 @Event('account-opened')
 class AccountOpenedEvent implements IEvent {
 	constructor(
-		public readonly initialBalance: number,
+		public readonly initialBalance: number = 0,
 		public readonly notes: string[] = [],
 	) {}
 }

--- a/packages/testing/unit/index.ts
+++ b/packages/testing/unit/index.ts
@@ -28,7 +28,12 @@ export class Account extends AggregateRoot {
 }
 
 @Event('account-opened')
-class AccountOpenedEvent implements IEvent {}
+class AccountOpenedEvent implements IEvent {
+	constructor(
+		public readonly initialBalance: number,
+		public readonly notes: string[] = [],
+	) {}
+}
 
 @Event('account-credited')
 class AccountCreditedEvent implements IEvent {
@@ -231,7 +236,7 @@ export const getEventMap = (): EventMap => {
 };
 
 export const getEvents = (): IEvent[] => [
-	new AccountOpenedEvent(),
+	new AccountOpenedEvent(0, ["Maisel's account"]),
 	new AccountCreditedEvent(50),
 	new AccountDebitedEvent(20),
 	new AccountCreditedEvent(5),


### PR DESCRIPTION
- **🧪 update testing data**
- **🐛 fix serializing event payloads in the Postgres driver**
- **🔖 add a changeset**

# Description

Fix serializing event payloads to save to the Postgres event-store.

Fixes #[499](https://github.com/ocoda/event-sourcing/issues/449)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

